### PR TITLE
Potential fix for code scanning alert no. 1: Clear text storage of sensitive information

### DIFF
--- a/server/app.mjs
+++ b/server/app.mjs
@@ -6,10 +6,10 @@ import rateLimit from 'express-rate-limit';
 import { OAuth2Client } from 'google-auth-library';
 import helmet from 'helmet';
 import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
 import { Resend } from 'resend';
 
 // --- Turso (libSQL) client --------------------------------------------------
-// Accept common env var aliases to reduce misconfiguration risk in deployments
 let tursoUrlSource = null;
 let tursoAuthSource = null;
 let tursoUrlRaw = null;
@@ -429,10 +429,15 @@ function issueSession(res, payload) {
     iss: 'goen-net',
     aud: 'goen-net-web'
   }, SESSION_SECRET, { algorithm: 'HS256', expiresIn: '7d' });
-  res.cookie('session', token, {
+
+  // Encrypt the token before setting in cookie
+  const encryptedToken = encrypt(token);
+
+  res.cookie('session', encryptedToken, {
     httpOnly: true,
     sameSite: 'strict', // stronger CSRF protection
     secure: isProd,
+
     path: '/',
     maxAge: 7 * 24 * 3600 * 1000,
   });
@@ -442,7 +447,13 @@ function issueSession(res, payload) {
 function decodeSession(req) {
   const raw = req.cookies?.session;
   if (!raw) return null;
-  try { return jwt.verify(raw, SESSION_SECRET); } catch { return null; }
+  try {
+    // Decrypt the token from the cookie, then verify JWT
+    const decryptedToken = decrypt(raw);
+    return jwt.verify(decryptedToken, SESSION_SECRET);
+  } catch {
+    return null;
+  }
 }
 
 // ---------------- Standardized response helpers ---------------------------


### PR DESCRIPTION
Potential fix for [https://github.com/hidenobunagai/goen-net/security/code-scanning/1](https://github.com/hidenobunagai/goen-net/security/code-scanning/1)

To fix this issue, the JWT's contents should either never hold sensitive information, or its payload should be encrypted before being stored in the cookie. In nearly all cases, the recommended approach is to store only a session ID or an opaque token (not user-sensitive information) in the cookie and keep sensitive user data server-side. If you must store a JWT with sensitive info on the client, encrypt its payload using a strong symmetric cipher before setting it as a cookie. The payload would be encrypted with a confidential, server-side key, and only decrypted by the server as needed. To implement this:

- Import Node.js `crypto` and create encrypt/decrypt helper functions (e.g., using AES-256-CTR).
- In `issueSession`, encrypt the JWT before storing it as a cookie.
- In `decodeSession`, decrypt the cookie value before verifying it with jwt.verify.
- Ensure `SESSION_SECRET` (JWT signing key) and the encryption key are separate and securely stored.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
