### PR TITLE
Potential fix for code scanning alert no. 5: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^6.26.2",
-    "resend": "^6.1.0"
+    "resend": "^6.1.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.11",

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -8,6 +8,7 @@ import helmet from 'helmet';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import { Resend } from 'resend';
+import { csrf } from 'lusca';
 
 // --- Turso (libSQL) client --------------------------------------------------
 let tursoUrlSource = null;
@@ -369,6 +370,7 @@ app.use(rateLimit({
 }));
 app.use(express.json({ limit: '64kb' })); // limit payload size (DoS mitigation)
 app.use(cookieParser());
+app.use(csrf());
 
 // Allow same-origin requests; if CORS_ORIGIN defined allow credentials
 const corsOrigin = process.env.CORS_ORIGIN;


### PR DESCRIPTION
Potential fix for [https://github.com/hidenobunagai/goen-net/security/code-scanning/5](https://github.com/hidenobunagai/goen-net/security/code-scanning/5)

To fix the missing CSRF middleware vulnerability, you should install and configure a well-known CSRF protection library (such as `lusca.csrf`). This involves:  
- Installing the `lusca` package as a dependency.  
- Importing the CSRF middleware from `lusca`.  
- Adding the CSRF middleware to the Express middleware stack **after** cookie and session middleware, but **before** any state-changing request handlers (like `app.delete(...)`).  
- (Optionally) Adding routes or mechanisms to provide the CSRF token to clients (as `lusca` stores it in a cookie by default, many frameworks support reading it from a cookie or by a special endpoint.)

In this particular code, modify `server/app.mjs` as follows:  
- Import `csrf` from `lusca`.  
- Insert `app.use(csrf());` after the cookie parser and session initialisation, and before any handlers.
No changes are needed elsewhere at this stage.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
