### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -109,25 +109,51 @@ const Home: React.FC = () => {
     return () => controller.abort()
   }, [loadNextSession])
 
+  // Only allow safe URLs in anchor tags to defend against XSS and protocol abuse.
+  const sanitizeUrl = (raw: string): string | null => {
+    try {
+      const url = new URL(raw, 'https://example.com') // base for relative URLs
+      // Allow only http: and https:
+      if (url.protocol === 'http:' || url.protocol === 'https:') {
+        // Remove control characters
+        return url.href.replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
+      }
+      return null
+    } catch {
+      return null
+    }
+  }
+
   const renderLocation = (value: string): React.ReactNode => {
     const text = (value || '').trim()
     if (!text) return 'Location TBD'
+    // Case 1: Already a complete http(s):// URL
     if (/^https?:\/\//i.test(text)) {
-      return <a href={text} target="_blank" rel="noopener noreferrer">{text}</a>
+      const trusted = sanitizeUrl(text)
+      if (trusted)
+        return <a href={trusted} target="_blank" rel="noopener noreferrer">{text}</a>
+      return text
     }
+    // Case 2: Looks like a domain or "www." URL, construct https://
     if (/^www\.[^\s]+$/i.test(text) || /^[\w.-]+\.[a-z]{2,}[^\s]*$/i.test(text)) {
       const url = `https://${text}`
-      return <a href={url} target="_blank" rel="noopener noreferrer">{text}</a>
+      const trusted = sanitizeUrl(url)
+      if (trusted)
+        return <a href={trusted} target="_blank" rel="noopener noreferrer">{text}</a>
+      return text
     }
+    // Case 3: Contains a http(s):// URL inside of text
     const match = text.match(/https?:\/\/\S+/i)
     if (!match || match.index == null) return text
     const url = match[0]
+    const trusted = sanitizeUrl(url)
+    if (!trusted) return text
     const prefix = text.slice(0, match.index)
     const suffix = text.slice(match.index + url.length)
     return (
       <>
         {prefix}
-        <a href={url} target="_blank" rel="noopener noreferrer">{url}</a>
+        <a href={trusted} target="_blank" rel="noopener noreferrer">{url}</a>
         {suffix}
       </>
     )


### PR DESCRIPTION
Potential fix for [https://github.com/hidenobunagai/goen-net/security/code-scanning/3](https://github.com/hidenobunagai/goen-net/security/code-scanning/3)

The core issue is allowing untrusted user data to be used unfiltered in attribute values (`href`), and as link text, which can lead to XSS or protocol confusion (e.g., `javascript:` links). Even though React escapes most data, it is safest to sanitize the input thoroughly. 

**General fix:**  
- Sanitize user-provided URLs before rendering.
- When creating links from user input, ensure the URLs start with an allowed protocol (`http`, `https`) and contain no unexpected control characters.
- For anchor text, display the original input but escape/strip dangerous characters.

**Detailed steps for this code:**  
- In `renderLocation`, before using user-provided `text` to construct `url` or as anchor text, validate that it's a valid domain or safe URL.
- For values used in `href` (like ``<a href={url} ...>{text}</a>`` or ``<a href={url} ...>{url}</a>``), ensure that:
    - Only `http://` and `https://` protocols are allowed (never `javascript:`, `data:`, etc.).
    - For domains (plain like `www.` or with TLD), ensure no control characters or dangerous substrings.
- Escape or filter the anchor text to not accidentally result in unwanted HTML (though this is mitigated by React).
- You may use the `URL` constructor for parsing, or a lightweight URL validation function.

**Where to change:**  
- Edit the `renderLocation` definition in `src/components/Home.tsx`, adding a helper (e.g. `sanitizeUrl`) to check/sanitize the link before forming the anchor.
- Precede the file's code with a helper function or inline the function in `renderLocation`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
