### PR TITLE
Align next session card spacing on mobile

### DIFF
--- a/src/app/(protected)/_components/next-session-card.tsx
+++ b/src/app/(protected)/_components/next-session-card.tsx
@@ -188,10 +188,16 @@ export function NextSessionCard({
     <Card
       sx={{
         height: "100%",
+        width: "100%",
         position: "relative",
         overflow: "hidden",
         backgroundImage:
           "linear-gradient(160deg, rgba(0,27,68,0.08), rgba(255,255,255,0.96))",
+        borderRadius: { xs: 3, md: 4 },
+        boxShadow: {
+          xs: "0px 12px 32px rgba(0, 44, 95, 0.12)",
+          md: "0px 16px 40px rgba(0, 44, 95, 0.18)",
+        },
       }}
     >
       <Box
@@ -203,7 +209,11 @@ export function NextSessionCard({
         }}
       />
       <CardContent
-        sx={{ position: "relative", zIndex: 1, p: { xs: 3, md: 4 } }}
+        sx={{
+          position: "relative",
+          zIndex: 1,
+          p: { xs: 3, sm: 3.5, md: 4 },
+        }}
       >
         <Stack spacing={3}>
           <Stack spacing={1}>
@@ -259,9 +269,20 @@ export function NextSessionCard({
         </Stack>
       </CardContent>
       <CardActions
-        sx={{ px: 3, pb: 3, pt: 0, position: "relative", zIndex: 1 }}
+        sx={{
+          px: { xs: 3, sm: 3.5, md: 4 },
+          pb: { xs: 3, sm: 3.5, md: 4 },
+          pt: 0,
+          position: "relative",
+          zIndex: 1,
+        }}
       >
-        <Button variant="contained" onClick={openDialog} disabled={isPending}>
+        <Button
+          variant="contained"
+          onClick={openDialog}
+          disabled={isPending}
+          fullWidth
+        >
           Edit details
         </Button>
       </CardActions>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,21 +61,7 @@ export default async function Home() {
             alignItems="center"
           >
             <Grid xs={1} md={5} order={{ xs: 1, md: 2 }}>
-              <Card
-                elevation={3}
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  p: { xs: 1.5, sm: 2, md: 2.5 },
-                  borderRadius: { xs: 3, md: 4 },
-                  boxShadow: {
-                    xs: "0px 12px 32px rgba(0, 44, 95, 0.12)",
-                    md: "0px 16px 40px rgba(0, 44, 95, 0.18)",
-                  },
-                }}
-              >
-                <NextSessionCard initial={nextSession} />
-              </Card>
+              <NextSessionCard initial={nextSession} />
             </Grid>
             <Grid xs={1} md={7} order={{ xs: 2, md: 1 }}>
               <Stack


### PR DESCRIPTION
## Summary
- move the next session card styling into the component so its gradient card keeps consistent padding and shadow on smaller screens
- simplify the home page hero grid by using the updated card directly, avoiding double padding that caused uneven horizontal spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db243ac07c8325a431c9e4c0ecf6f3