### PR TITLE
Fix overflow in update details dialog

### DIFF
--- a/src/app/(protected)/updates/_components/updates-list.tsx
+++ b/src/app/(protected)/updates/_components/updates-list.tsx
@@ -733,7 +733,14 @@ export function UpdatesBoard({
                 </Box>
                 <UpdateStatusBadge urgent={detailsItem.urgent} />
               </Stack>
-              <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+              <Typography
+                variant="body2"
+                sx={{
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  overflowWrap: "anywhere",
+                }}
+              >
                 {detailsItem.body}
               </Typography>
             </Stack>


### PR DESCRIPTION
## Summary
- prevent long update bodies from overflowing their dialog by allowing breaks inside the text content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbbb58a2748325b920b7b40ab5ade5