### PR TITLE
Stop using in-memory fallbacks when Turso is unavailable

### DIFF
--- a/src/app/api/next-session/route.ts
+++ b/src/app/api/next-session/route.ts
@@ -1,5 +1,5 @@
 import { getOptionalUserSession } from "@/lib/session";
-import { getNextSession, upsertNextSession } from "@/lib/turso";
+import { TursoUnavailableError, getNextSession, upsertNextSession } from "@/lib/turso";
 import { NextResponse } from "next/server";
 
 export async function GET() {
@@ -21,12 +21,15 @@ export async function GET() {
     });
   } catch (error) {
     console.error("Failed to load next session", error);
+    const unavailable = error instanceof TursoUnavailableError;
     return NextResponse.json(
       {
         ok: false,
         error: {
-          code: "FETCH_FAILED",
-          message: "Unable to load the next session. Please try again later.",
+          code: unavailable ? "DATABASE_UNAVAILABLE" : "FETCH_FAILED",
+          message: unavailable
+            ? "The next session cannot be loaded because the database is unavailable right now."
+            : "Unable to load the next session. Please try again later.",
         },
       },
       { status: 503 }
@@ -86,12 +89,15 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: true });
   } catch (error) {
     console.error("Failed to update next session", error);
+    const unavailable = error instanceof TursoUnavailableError;
     return NextResponse.json(
       {
         ok: false,
         error: {
-          code: "UPDATE_FAILED",
-          message: "Unable to update the next session right now.",
+          code: unavailable ? "DATABASE_UNAVAILABLE" : "UPDATE_FAILED",
+          message: unavailable
+            ? "The next session cannot be updated because the database is unavailable. Please try again once connectivity is restored."
+            : "Unable to update the next session right now.",
         },
       },
       { status: 503 }

--- a/src/app/api/updates/[id]/route.ts
+++ b/src/app/api/updates/[id]/route.ts
@@ -1,4 +1,5 @@
 import { getOptionalUserSession } from "@/lib/session";
+import { TursoUnavailableError } from "@/lib/turso";
 import { deleteUpdate, getUpdateById } from "@/lib/updates";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
@@ -51,12 +52,15 @@ export async function GET(
     return NextResponse.json({ ok: true, update });
   } catch (error) {
     console.error("Failed to load update", error);
+    const unavailable = error instanceof TursoUnavailableError;
     return NextResponse.json(
       {
         ok: false,
         error: {
-          code: "FETCH_FAILED",
-          message: "Unable to load this update right now.",
+          code: unavailable ? "DATABASE_UNAVAILABLE" : "FETCH_FAILED",
+          message: unavailable
+            ? "This update cannot be loaded because the database is unavailable right now."
+            : "Unable to load this update right now.",
         },
       },
       { status: 503 }
@@ -112,12 +116,15 @@ export async function DELETE(
     return NextResponse.json({ ok: true });
   } catch (error) {
     console.error("Failed to delete update", error);
+    const unavailable = error instanceof TursoUnavailableError;
     return NextResponse.json(
       {
         ok: false,
         error: {
-          code: "DELETE_FAILED",
-          message: "Unable to delete this update right now.",
+          code: unavailable ? "DATABASE_UNAVAILABLE" : "DELETE_FAILED",
+          message: unavailable
+            ? "This update cannot be modified because the database connection is unavailable."
+            : "Unable to delete this update right now.",
         },
       },
       { status: 503 }

--- a/src/app/api/updates/route.ts
+++ b/src/app/api/updates/route.ts
@@ -1,5 +1,6 @@
 import { checkRateLimit } from "@/lib/rate-limit";
 import { getOptionalUserSession } from "@/lib/session";
+import { TursoUnavailableError } from "@/lib/turso";
 import type { UpdateRecord } from "@/lib/updates";
 import {
   deleteAllUpdates,
@@ -60,12 +61,15 @@ export async function GET(request: Request) {
     return NextResponse.json({ ok: true, updates });
   } catch (error) {
     console.error("Failed to fetch updates", error);
+    const unavailable = error instanceof TursoUnavailableError;
     return NextResponse.json(
       {
         ok: false,
         error: {
-          code: "FETCH_FAILED",
-          message: "Unable to load updates right now. Please try again soon.",
+          code: unavailable ? "DATABASE_UNAVAILABLE" : "FETCH_FAILED",
+          message: unavailable
+            ? "Updates cannot be loaded because the database is currently unavailable."
+            : "Unable to load updates right now. Please try again soon.",
         },
       },
       { status: 503 }
@@ -183,13 +187,15 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("Failed to create update", error);
+    const unavailable = error instanceof TursoUnavailableError;
     return NextResponse.json(
       {
         ok: false,
         error: {
-          code: "CREATE_FAILED",
-          message:
-            "Unable to create an update right now. Please try again later.",
+          code: unavailable ? "DATABASE_UNAVAILABLE" : "CREATE_FAILED",
+          message: unavailable
+            ? "Updates cannot be posted right now because the database is unavailable. 現在はデータベースに接続できないため投稿できません。サービス復旧後に再度お試しください。"
+            : "Unable to create an update right now. Please try again later.",
         },
       },
       { status: 503 }
@@ -268,13 +274,15 @@ export async function DELETE() {
     return NextResponse.json({ ok: true, deleted });
   } catch (error) {
     console.error("Failed to delete updates", error);
+    const unavailable = error instanceof TursoUnavailableError;
     return NextResponse.json(
       {
         ok: false,
         error: {
-          code: "DELETE_FAILED",
-          message:
-            "Unable to delete updates right now. Please try again later.",
+          code: unavailable ? "DATABASE_UNAVAILABLE" : "DELETE_FAILED",
+          message: unavailable
+            ? "Updates cannot be cleared right now because the database is unavailable."
+            : "Unable to delete updates right now. Please try again later.",
         },
       },
       { status: 503 }

--- a/src/lib/turso.ts
+++ b/src/lib/turso.ts
@@ -122,8 +122,6 @@ export type NextSessionRecord = {
   updatedAt: string | null;
 };
 
-let memoryNextSession: NextSessionRecord | null = null;
-
 function normalizeRow(
   row: Record<string, unknown> | undefined
 ): NextSessionRecord | null {
@@ -148,21 +146,14 @@ function normalizeRow(
 
 export async function getNextSession(): Promise<NextSessionRecord | null> {
   if (!isTursoConfigured()) {
-    return memoryNextSession;
+    throw new TursoUnavailableError();
   }
 
-  try {
-    const result = await execute(
-      "SELECT start_at, end_at, location, updated_at FROM next_session WHERE id = 1 LIMIT 1"
-    );
-    const row = result.rows?.[0] as Record<string, unknown> | undefined;
-    return normalizeRow(row ?? undefined);
-  } catch (error) {
-    if (error instanceof TursoUnavailableError) {
-      return memoryNextSession;
-    }
-    throw error;
-  }
+  const result = await execute(
+    "SELECT start_at, end_at, location, updated_at FROM next_session WHERE id = 1 LIMIT 1"
+  );
+  const row = result.rows?.[0] as Record<string, unknown> | undefined;
+  return normalizeRow(row ?? undefined);
 }
 
 export type UpsertNextSessionInput = {
@@ -177,36 +168,17 @@ export async function upsertNextSession({
   location,
 }: UpsertNextSessionInput): Promise<void> {
   if (!isTursoConfigured()) {
-    memoryNextSession = {
-      startAt,
-      endAt,
-      location,
-      updatedAt: new Date().toISOString(),
-    };
-    return;
+    throw new TursoUnavailableError();
   }
 
-  try {
-    await execute(
-      `INSERT INTO next_session (id, start_at, end_at, location, updated_at)
+  await execute(
+    `INSERT INTO next_session (id, start_at, end_at, location, updated_at)
        VALUES (1, ?1, ?2, ?3, datetime('now'))
        ON CONFLICT(id) DO UPDATE SET
          start_at = excluded.start_at,
          end_at = excluded.end_at,
          location = excluded.location,
          updated_at = datetime('now')`,
-      [startAt, endAt, location]
-    );
-  } catch (error) {
-    if (error instanceof TursoUnavailableError) {
-      memoryNextSession = {
-        startAt,
-        endAt,
-        location,
-        updatedAt: new Date().toISOString(),
-      };
-      return;
-    }
-    throw error;
-  }
+    [startAt, endAt, location]
+  );
 }

--- a/src/lib/updates.ts
+++ b/src/lib/updates.ts
@@ -29,63 +29,10 @@ type FetchOptions = {
   offset?: number;
 };
 
-type MemoryUpdate = {
-  id: string;
-  by: string;
-  category: UpdateCategory;
-  urgent: boolean;
-  uid: string;
-  title: string;
-  body: string;
-  when: UpdateWhen;
-  createdAt: string;
-};
-
-type UpdatesMemoryStore = {
-  updates: MemoryUpdate[];
-  fallbackEnabled: boolean;
-};
-
-const globalUpdatesStore = globalThis as typeof globalThis & {
-  __goenNetUpdatesMemory?: UpdatesMemoryStore;
-};
-
-if (!globalUpdatesStore.__goenNetUpdatesMemory) {
-  globalUpdatesStore.__goenNetUpdatesMemory = {
-    updates: [],
-    fallbackEnabled: false,
-  };
-}
-
-const memoryStore = globalUpdatesStore.__goenNetUpdatesMemory;
-const memoryUpdates = memoryStore.updates;
-
-function shouldUseMemory(): boolean {
-  return memoryStore.fallbackEnabled || !isTursoConfigured();
-}
-
-function fallbackToMemoryOnError(error: unknown): boolean {
-  if (shouldUseMemory()) {
-    return true;
+function assertTursoAvailable(): void {
+  if (!isTursoConfigured()) {
+    throw new TursoUnavailableError();
   }
-
-  const allowFallback =
-    error instanceof TursoUnavailableError ||
-    process.env.NODE_ENV !== "production";
-
-  if (!allowFallback) {
-    return false;
-  }
-
-  if (!memoryStore.fallbackEnabled) {
-    console.warn(
-      "[updates] Falling back to in-memory storage for updates operations.",
-      error
-    );
-    memoryStore.fallbackEnabled = true;
-  }
-
-  return true;
 }
 
 type UsersTableSchema = {
@@ -451,9 +398,7 @@ function toUpdateRecord(
 }
 
 async function ensureUserProfile(uid: string, name: string): Promise<void> {
-  if (shouldUseMemory()) {
-    return;
-  }
+  assertTursoAvailable();
 
   const safeName = name?.trim() || uid;
 
@@ -522,163 +467,62 @@ ${conflictClause}`;
   }
 }
 
-function toTimestamp(value: string): number {
-  const parsed = Date.parse(value);
-  return Number.isNaN(parsed) ? 0 : parsed;
-}
-
-function toRecordFromMemory(
-  item: MemoryUpdate,
-  viewerId: string
-): UpdateRecord {
-  return {
-    id: item.id,
-    by: item.by,
-    category: item.category,
-    urgent: item.urgent,
-    uid: item.uid,
-    title: item.title,
-    body: item.body,
-    when: item.when,
-    createdAt: item.createdAt,
-    viewerIsOwner: item.uid === viewerId,
-  };
-}
-
-function fetchUpdatesFromMemory(
-  viewerId: string,
-  { limit = 50, offset = 0 }: FetchOptions = {}
-): UpdateRecord[] {
-  return memoryUpdates
-    .slice()
-    .sort((a, b) => toTimestamp(b.createdAt) - toTimestamp(a.createdAt))
-    .slice(offset, offset + limit)
-    .map((item) => toRecordFromMemory(item, viewerId));
-}
-
-function getUpdateFromMemory(
-  id: string,
-  viewerId: string
-): UpdateRecord | null {
-  const match = memoryUpdates.find((item) => item.id === id);
-  return match ? toRecordFromMemory(match, viewerId) : null;
-}
-
-function insertUpdateIntoMemory(params: {
-  id: string;
-  by: string;
-  category: UpdateCategory;
-  urgent: boolean;
-  uid: string;
-  title: string | null;
-  body: string;
-  when: UpdateWhen;
-}): void {
-  const createdAt = new Date().toISOString();
-  const title = params.title ?? (params.body.slice(0, 80) || "Untitled");
-  const item: MemoryUpdate = {
-    id: params.id,
-    by: params.by,
-    category: params.category,
-    urgent: params.urgent,
-    uid: params.uid,
-    title,
-    body: params.body,
-    when: params.when,
-    createdAt,
-  };
-  memoryUpdates.unshift(item);
-}
-
-function deleteUpdateFromMemory(id: string, uid: string): boolean {
-  const index = memoryUpdates.findIndex(
-    (item) => item.id === id && item.uid === uid
-  );
-  if (index === -1) return false;
-  memoryUpdates.splice(index, 1);
-  return true;
-}
-
-function deleteAllUpdatesFromMemory(): number {
-  const deleted = memoryUpdates.length;
-  memoryUpdates.splice(0, memoryUpdates.length);
-  return deleted;
-}
-
 export async function fetchUpdates(
   viewerId: string,
   { limit = 50, offset = 0 }: FetchOptions = {}
 ): Promise<UpdateRecord[]> {
-  if (shouldUseMemory()) {
-    return fetchUpdatesFromMemory(viewerId, { limit, offset });
-  }
+  assertTursoAvailable();
 
   const schema = await getUpdatesTableSchema();
 
   const orderBy =
     schema.createdAtColumn ?? schema.updatedAtColumn ?? schema.idColumn;
 
-  try {
-    const result = await execute(
-      `SELECT * FROM updates ORDER BY ${orderBy} DESC LIMIT ?1 OFFSET ?2`,
-      [limit, offset] as InArgs
-    );
+  const result = await execute(
+    `SELECT * FROM updates ORDER BY ${orderBy} DESC LIMIT ?1 OFFSET ?2`,
+    [limit, offset] as InArgs
+  );
 
-    const records: Record<string, unknown>[] = [];
-    for (const row of result.rows ?? []) {
-      const record = toRecord(row);
-      if (record) {
-        records.push(record);
-      }
+  const records: Record<string, unknown>[] = [];
+  for (const row of result.rows ?? []) {
+    const record = toRecord(row);
+    if (record) {
+      records.push(record);
     }
-
-    const updates: UpdateRecord[] = [];
-    for (const record of records) {
-      const update = toUpdateRecord(record, schema, viewerId);
-      if (update) {
-        updates.push(update);
-      }
-    }
-
-    return updates;
-  } catch (error) {
-    if (fallbackToMemoryOnError(error)) {
-      return fetchUpdatesFromMemory(viewerId, { limit, offset });
-    }
-    throw error;
   }
+
+  const updates: UpdateRecord[] = [];
+  for (const record of records) {
+    const update = toUpdateRecord(record, schema, viewerId);
+    if (update) {
+      updates.push(update);
+    }
+  }
+
+  return updates;
 }
 
 export async function getUpdateById(
   id: string,
   viewerId: string
 ): Promise<UpdateRecord | null> {
-  if (shouldUseMemory()) {
-    return getUpdateFromMemory(id, viewerId);
-  }
+  assertTursoAvailable();
 
   const schema = await getUpdatesTableSchema();
 
-  try {
-    const result = await execute(
-      `SELECT * FROM updates WHERE ${schema.idColumn} = ?1 LIMIT 1`,
-      [id] as InArgs
-    );
+  const result = await execute(
+    `SELECT * FROM updates WHERE ${schema.idColumn} = ?1 LIMIT 1`,
+    [id] as InArgs
+  );
 
-    const row = result.rows?.[0];
-    const record = toRecord(row);
-    if (!record) {
-      return null;
-    }
-
-    const update = toUpdateRecord(record, schema, viewerId);
-    return update;
-  } catch (error) {
-    if (fallbackToMemoryOnError(error)) {
-      return getUpdateFromMemory(id, viewerId);
-    }
-    throw error;
+  const row = result.rows?.[0];
+  const record = toRecord(row);
+  if (!record) {
+    return null;
   }
+
+  const update = toUpdateRecord(record, schema, viewerId);
+  return update;
 }
 
 export async function insertUpdate(params: {
@@ -691,108 +535,77 @@ export async function insertUpdate(params: {
   body: string;
   when: UpdateWhen;
 }): Promise<void> {
-  if (shouldUseMemory()) {
-    insertUpdateIntoMemory(params);
-    return;
-  }
+  assertTursoAvailable();
 
-  try {
-    await ensureUserProfile(params.uid, params.by);
+  await ensureUserProfile(params.uid, params.by);
 
-    const schema = await getUpdatesTableSchema();
+  const schema = await getUpdatesTableSchema();
 
-    const columns: string[] = [];
-    const values: string[] = [];
-    const args: (string | number | null)[] = [];
+  const columns: string[] = [];
+  const values: string[] = [];
+  const args: (string | number | null)[] = [];
 
-    const pushValue = (
-      columnName: string | undefined,
-      value: string | number | null
-    ) => {
-      if (!columnName) {
-        return;
-      }
-      columns.push(columnName);
-      args.push(value);
-      values.push(`?${args.length}`);
-    };
-
-    pushValue(schema.idColumn, params.id);
-    pushValue(schema.byNameColumn, params.by);
-    pushValue(schema.categoryColumn, params.category);
-
-    const urgentValue = params.urgent ? 1 : 0;
-    if (schema.priorityColumn) {
-      pushValue(schema.priorityColumn, urgentValue);
-    }
-    if (schema.urgentColumn && schema.urgentColumn !== schema.priorityColumn) {
-      pushValue(schema.urgentColumn, urgentValue);
-    }
-
-    pushValue(schema.uidColumn, params.uid);
-    pushValue(schema.titleColumn, params.title ?? null);
-    pushValue(schema.bodyColumn, params.body);
-    pushValue(schema.whenValueColumn, params.when);
-
-    if (schema.createdAtColumn) {
-      columns.push(schema.createdAtColumn);
-      values.push("datetime('now')");
-    }
-
-    if (schema.updatedAtColumn) {
-      columns.push(schema.updatedAtColumn);
-      values.push("datetime('now')");
-    }
-
-    const sql = `INSERT INTO updates (${columns.join(
-      ", "
-    )}) VALUES (${values.join(", ")})`;
-
-    await execute(sql, args as InArgs);
-  } catch (error) {
-    if (fallbackToMemoryOnError(error)) {
-      insertUpdateIntoMemory(params);
+  const pushValue = (
+    columnName: string | undefined,
+    value: string | number | null
+  ) => {
+    if (!columnName) {
       return;
     }
-    throw error;
+    columns.push(columnName);
+    args.push(value);
+    values.push(`?${args.length}`);
+  };
+
+  pushValue(schema.idColumn, params.id);
+  pushValue(schema.byNameColumn, params.by);
+  pushValue(schema.categoryColumn, params.category);
+
+  const urgentValue = params.urgent ? 1 : 0;
+  if (schema.priorityColumn) {
+    pushValue(schema.priorityColumn, urgentValue);
   }
+  if (schema.urgentColumn && schema.urgentColumn !== schema.priorityColumn) {
+    pushValue(schema.urgentColumn, urgentValue);
+  }
+
+  pushValue(schema.uidColumn, params.uid);
+  pushValue(schema.titleColumn, params.title ?? null);
+  pushValue(schema.bodyColumn, params.body);
+  pushValue(schema.whenValueColumn, params.when);
+
+  if (schema.createdAtColumn) {
+    columns.push(schema.createdAtColumn);
+    values.push("datetime('now')");
+  }
+
+  if (schema.updatedAtColumn) {
+    columns.push(schema.updatedAtColumn);
+    values.push("datetime('now')");
+  }
+
+  const sql = `INSERT INTO updates (${columns.join(", ")}) VALUES (${values.join(", ")})`;
+
+  await execute(sql, args as InArgs);
 }
 
 export async function deleteUpdate(id: string, uid: string): Promise<boolean> {
-  if (shouldUseMemory()) {
-    return deleteUpdateFromMemory(id, uid);
-  }
+  assertTursoAvailable();
 
   const schema = await getUpdatesTableSchema();
   const hasUidColumn = Boolean(schema.uidColumn);
 
-  try {
-    const sql = hasUidColumn
-      ? `DELETE FROM updates WHERE ${schema.idColumn} = ?1 AND ${schema.uidColumn} = ?2`
-      : `DELETE FROM updates WHERE ${schema.idColumn} = ?1`;
-    const args: (string | number)[] = hasUidColumn ? [id, uid] : [id];
-    const result = await execute(sql, args as InArgs);
-    return (result.rowsAffected ?? 0) > 0;
-  } catch (error) {
-    if (fallbackToMemoryOnError(error)) {
-      return deleteUpdateFromMemory(id, uid);
-    }
-    throw error;
-  }
+  const sql = hasUidColumn
+    ? `DELETE FROM updates WHERE ${schema.idColumn} = ?1 AND ${schema.uidColumn} = ?2`
+    : `DELETE FROM updates WHERE ${schema.idColumn} = ?1`;
+  const args: (string | number)[] = hasUidColumn ? [id, uid] : [id];
+  const result = await execute(sql, args as InArgs);
+  return (result.rowsAffected ?? 0) > 0;
 }
 
 export async function deleteAllUpdates(): Promise<number> {
-  if (shouldUseMemory()) {
-    return deleteAllUpdatesFromMemory();
-  }
+  assertTursoAvailable();
 
-  try {
-    const result = await execute(`DELETE FROM updates`);
-    return result.rowsAffected ?? 0;
-  } catch (error) {
-    if (fallbackToMemoryOnError(error)) {
-      return deleteAllUpdatesFromMemory();
-    }
-    throw error;
-  }
+  const result = await execute(`DELETE FROM updates`);
+  return result.rowsAffected ?? 0;
 }


### PR DESCRIPTION
## Summary
- require a configured Turso connection for update persistence helpers instead of silently degrading to memory
- throw when Turso cannot be reached for next-session helpers so API handlers can report outages
- return explicit database-unavailable errors from updates and next-session APIs to inform users they cannot post right now

## Testing
- npm run lint
- npm run test:updates

------
https://chatgpt.com/codex/tasks/task_e_68dbbd8db7d48325a9ab78221b5c9782