### PR TITLE
Remove date from prioritization cards

### DIFF
--- a/src/app/(protected)/prioritization/_components/prioritization-board.tsx
+++ b/src/app/(protected)/prioritization/_components/prioritization-board.tsx
@@ -227,18 +227,6 @@ function findColumnIdByItem(
   return null;
 }
 
-function formatDate(date: Date): string {
-  try {
-    return new Intl.DateTimeFormat(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    }).format(date);
-  } catch {
-    return date.toISOString().split("T")[0];
-  }
-}
-
 export function PrioritizationBoard() {
   const [updates, setUpdates] = useState<UpdateItem[]>([]);
   const [board, setBoard] = useState<BoardState | null>(null);
@@ -966,14 +954,11 @@ function UpdateCard({ item, isDragging }: UpdateCardProps) {
       <Stack
         direction="row"
         spacing={1}
-        justifyContent="space-between"
+        justifyContent="flex-start"
         alignItems="center"
       >
         <Typography variant="caption" color="text.secondary">
           {item.by}
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          {formatDate(item.createdAt)}
         </Typography>
       </Stack>
     </Paper>


### PR DESCRIPTION
## Summary
- remove the unused date formatting helper from the prioritization board
- update prioritization cards to stop rendering the created date and keep the author label aligned

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbc29c9b4c8325a69a45f7a8b19ffc