### PR TITLE
Enhance presenter worksheet header styling

### DIFF
--- a/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
@@ -2,9 +2,11 @@
 
 import { useDocumentTitle } from "@/hooks/use-document-title";
 import {
+  Avatar,
   Box,
   Button,
   Checkbox,
+  Chip,
   Container,
   Divider,
   FormControlLabel,
@@ -343,6 +345,27 @@ export function CoachWorksheet() {
     },
   ];
 
+  const headerHighlights = useMemo(
+    () => [
+      {
+        title: "Create shared clarity",
+        description:
+          "Listen for emotions and facts so the presenter can articulate the core issue.",
+      },
+      {
+        title: "Coach with intention",
+        description:
+          "Use open questions to surface insights, options, and desired outcomes.",
+      },
+      {
+        title: "Set the team up",
+        description:
+          "Frame the confidentiality level and what support the presenter needs from peers.",
+      },
+    ],
+    []
+  );
+
   return (
     <Container maxWidth="md" sx={{ my: 4, pb: 8 }}>
       <Stack spacing={3}>
@@ -353,26 +376,118 @@ export function CoachWorksheet() {
             border: "1px solid",
             borderColor: "primary.light",
             background:
-              "linear-gradient(135deg, rgba(14,116,144,0.12), rgba(59,130,246,0.08))",
+              "linear-gradient(135deg, rgba(14,116,144,0.18), rgba(59,130,246,0.14))",
             boxShadow: "0 24px 60px rgba(15, 23, 42, 0.16)",
+            position: "relative",
+            overflow: "hidden",
+            isolation: "isolate",
+            "&::after": {
+              content: "''",
+              position: "absolute",
+              inset: 0,
+              background:
+                "radial-gradient(140px at 15% 15%, rgba(255,255,255,0.5), transparent 65%), radial-gradient(200px at 85% 5%, rgba(125,211,252,0.35), transparent 60%)",
+              pointerEvents: "none",
+              zIndex: -1,
+            },
           }}
         >
-          <Stack spacing={1.5}>
-            <Typography
-              variant="h4"
-              sx={{ fontWeight: 800, color: "primary.dark" }}
-              gutterBottom
+          <Stack spacing={3}>
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={2}
+              alignItems={{ sm: "center" }}
             >
-              Coaching Worksheet [For Coaches]
-            </Typography>
-            <Typography
-              color="text.secondary"
-              sx={{ fontSize: 14, maxWidth: 720 }}
-            >
-              Review the presentation sheet together with the presenter. Listen
-              and ask questions to help understand what really the problem is.
-              Then, fill out this sheet and use it to introduce the presenter.
-            </Typography>
+              <Avatar
+                sx={{
+                  width: 64,
+                  height: 64,
+                  bgcolor: "primary.main",
+                  color: "primary.contrastText",
+                  fontSize: 32,
+                  boxShadow: "0 16px 40px rgba(14, 116, 144, 0.35)",
+                }}
+              >
+                🧭
+              </Avatar>
+              <Box>
+                <Chip
+                  label="Coach role"
+                  color="primary"
+                  variant="outlined"
+                  size="small"
+                  sx={{
+                    fontWeight: 600,
+                    mb: 1,
+                    bgcolor: "rgba(255,255,255,0.24)",
+                    borderColor: "rgba(125, 211, 252, 0.6)",
+                  }}
+                />
+                <Typography
+                  variant="h4"
+                  sx={{ fontWeight: 800, color: "primary.dark" }}
+                >
+                  Coaching Worksheet
+                </Typography>
+                <Typography
+                  variant="subtitle1"
+                  sx={{ fontWeight: 600, color: "primary.dark", mt: 0.5 }}
+                >
+                  Guide the presenter to surface the real issue and prepare the
+                  cohort to support effectively.
+                </Typography>
+              </Box>
+            </Stack>
+
+            <Divider sx={{ borderColor: "rgba(125, 211, 252, 0.4)" }} />
+
+            <Stack spacing={2}>
+              <Typography
+                color="text.secondary"
+                sx={{ fontSize: 14, maxWidth: 760 }}
+              >
+                Review the presentation sheet together, listen deeply, and use
+                this worksheet to introduce the presenter with clarity.
+              </Typography>
+
+              <Stack
+                direction={{ xs: "column", md: "row" }}
+                spacing={2}
+                sx={{
+                  "& > *": {
+                    flex: 1,
+                  },
+                }}
+              >
+                {headerHighlights.map((highlight) => (
+                  <Box
+                    key={highlight.title}
+                    sx={{
+                      px: 2,
+                      py: 1.5,
+                      borderRadius: 2.5,
+                      border: "1px solid rgba(125, 211, 252, 0.45)",
+                      bgcolor: "rgba(255,255,255,0.28)",
+                      boxShadow: "inset 0 1px 0 rgba(255,255,255,0.35)",
+                      backdropFilter: "blur(6px)",
+                    }}
+                  >
+                    <Typography
+                      variant="subtitle2"
+                      sx={{ fontWeight: 700, color: "primary.dark" }}
+                    >
+                      {highlight.title}
+                    </Typography>
+                    <Typography
+                      variant="body2"
+                      sx={{ color: "text.secondary", mt: 0.5 }}
+                    >
+                      {highlight.description}
+                    </Typography>
+                  </Box>
+                ))}
+              </Stack>
+            </Stack>
           </Stack>
         </Paper>
 

--- a/src/app/(protected)/worksheets/_components/observer-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/observer-worksheet.tsx
@@ -2,9 +2,12 @@
 
 import { useDocumentTitle } from "@/hooks/use-document-title";
 import {
+  Avatar,
   Box,
   Button,
+  Chip,
   Container,
+  Divider,
   Paper,
   Stack,
   TextField,
@@ -112,6 +115,27 @@ export function ObserverWorksheet() {
     []
   );
 
+  const headerHighlights = useMemo(
+    () => [
+      {
+        title: "Observe patterns",
+        description:
+          "Capture moments that showcase effective collaboration and meeting flow.",
+      },
+      {
+        title: "Spot opportunities",
+        description:
+          "Document where the team can communicate with more empathy and rigor.",
+      },
+      {
+        title: "Share actionable feedback",
+        description:
+          "Synthesize observations into insights the cohort can apply immediately.",
+      },
+    ],
+    []
+  );
+
   return (
     <Container maxWidth="md" sx={{ my: 4, pb: 8 }}>
       <Stack spacing={3}>
@@ -120,28 +144,120 @@ export function ObserverWorksheet() {
             p: { xs: 3, md: 4 },
             borderRadius: 4,
             border: "1px solid",
-            borderColor: "primary.light",
+            borderColor: "secondary.light",
             background:
-              "linear-gradient(135deg, rgba(59,130,246,0.12), rgba(37,99,235,0.08))",
+              "linear-gradient(135deg, rgba(129,140,248,0.18), rgba(99,102,241,0.14))",
             boxShadow: "0 24px 60px rgba(15, 23, 42, 0.16)",
+            position: "relative",
+            overflow: "hidden",
+            isolation: "isolate",
+            "&::after": {
+              content: "''",
+              position: "absolute",
+              inset: 0,
+              background:
+                "radial-gradient(140px at 18% 20%, rgba(255,255,255,0.45), transparent 65%), radial-gradient(220px at 82% 10%, rgba(165,180,252,0.35), transparent 60%)",
+              pointerEvents: "none",
+              zIndex: -1,
+            },
           }}
         >
-          <Stack spacing={1.5}>
-            <Typography
-              variant="h4"
-              sx={{ fontWeight: 800, color: "primary.dark" }}
-              gutterBottom
+          <Stack spacing={3}>
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={2}
+              alignItems={{ sm: "center" }}
             >
-              Process Feedback Sheet [For Process Observers]
-            </Typography>
-            <Typography
-              color="text.secondary"
-              sx={{ fontSize: 14, maxWidth: 720 }}
-            >
-              The process observer’s role is to observe a meeting while
-              participating, and give feedback for everybody to learn from good
-              examples and to improve the quality of a meeting.
-            </Typography>
+              <Avatar
+                sx={{
+                  width: 64,
+                  height: 64,
+                  bgcolor: "secondary.main",
+                  color: "secondary.contrastText",
+                  fontSize: 32,
+                  boxShadow: "0 16px 40px rgba(99, 102, 241, 0.35)",
+                }}
+              >
+                👀
+              </Avatar>
+              <Box>
+                <Chip
+                  label="Process observer"
+                  color="secondary"
+                  variant="outlined"
+                  size="small"
+                  sx={{
+                    fontWeight: 600,
+                    mb: 1,
+                    bgcolor: "rgba(255,255,255,0.24)",
+                    borderColor: "rgba(165, 180, 252, 0.6)",
+                  }}
+                />
+                <Typography
+                  variant="h4"
+                  sx={{ fontWeight: 800, color: "secondary.dark" }}
+                >
+                  Process Feedback Worksheet
+                </Typography>
+                <Typography
+                  variant="subtitle1"
+                  sx={{ fontWeight: 600, color: "secondary.dark", mt: 0.5 }}
+                >
+                  Capture the meeting dynamics so the team can celebrate wins
+                  and adjust behaviours together.
+                </Typography>
+              </Box>
+            </Stack>
+
+            <Divider sx={{ borderColor: "rgba(165, 180, 252, 0.4)" }} />
+
+            <Stack spacing={2}>
+              <Typography
+                color="text.secondary"
+                sx={{ fontSize: 14, maxWidth: 760 }}
+              >
+                Observe while participating, note concrete examples, and
+                translate them into collective learning for your cohort.
+              </Typography>
+
+              <Stack
+                direction={{ xs: "column", md: "row" }}
+                spacing={2}
+                sx={{
+                  "& > *": {
+                    flex: 1,
+                  },
+                }}
+              >
+                {headerHighlights.map((highlight) => (
+                  <Box
+                    key={highlight.title}
+                    sx={{
+                      px: 2,
+                      py: 1.5,
+                      borderRadius: 2.5,
+                      border: "1px solid rgba(165, 180, 252, 0.45)",
+                      bgcolor: "rgba(255,255,255,0.28)",
+                      boxShadow: "inset 0 1px 0 rgba(255,255,255,0.35)",
+                      backdropFilter: "blur(6px)",
+                    }}
+                  >
+                    <Typography
+                      variant="subtitle2"
+                      sx={{ fontWeight: 700, color: "secondary.dark" }}
+                    >
+                      {highlight.title}
+                    </Typography>
+                    <Typography
+                      variant="body2"
+                      sx={{ color: "text.secondary", mt: 0.5 }}
+                    >
+                      {highlight.description}
+                    </Typography>
+                  </Box>
+                ))}
+              </Stack>
+            </Stack>
           </Stack>
         </Paper>
 

--- a/src/app/(protected)/worksheets/_components/presenter-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/presenter-worksheet.tsx
@@ -2,10 +2,13 @@
 
 import { useDocumentTitle } from "@/hooks/use-document-title";
 import {
+  Avatar,
   Box,
   Button,
   Checkbox,
+  Chip,
   Container,
+  Divider,
   FormControlLabel,
   FormGroup,
   Paper,
@@ -102,6 +105,27 @@ export function PresenterWorksheet() {
     []
   );
 
+  const headerHighlights = useMemo(
+    () => [
+      {
+        title: "Clarify the story",
+        description:
+          "Capture the context, emotions, and expectations around the issue.",
+      },
+      {
+        title: "Co-create insight",
+        description:
+          "Partner with your coach to surface perspectives and options.",
+      },
+      {
+        title: "Plan your ask",
+        description:
+          "Shape a clear request that invites support from your peers.",
+      },
+    ],
+    []
+  );
+
   return (
     <Container maxWidth="md" sx={{ my: 4, pb: 8 }}>
       <Stack spacing={3}>
@@ -114,28 +138,120 @@ export function PresenterWorksheet() {
             background:
               "linear-gradient(135deg, rgba(251,191,36,0.16), rgba(249,115,22,0.12))",
             boxShadow: "0 24px 60px rgba(15, 23, 42, 0.16)",
+            position: "relative",
+            overflow: "hidden",
+            isolation: "isolate",
+            "&::after": {
+              content: "''",
+              position: "absolute",
+              inset: 0,
+              background:
+                "radial-gradient(120px at 20% 20%, rgba(255,255,255,0.48), transparent 65%), radial-gradient(180px at 80% 10%, rgba(253,186,116,0.28), transparent 55%)",
+              pointerEvents: "none",
+              zIndex: -1,
+            },
           }}
         >
-          <Stack spacing={1.5}>
-            <Typography
-              variant="h4"
-              sx={{ fontWeight: 800, color: "warning.dark" }}
-              gutterBottom
+          <Stack spacing={3}>
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={2}
+              alignItems={{ sm: "center" }}
             >
-              Presentation Worksheet [For Presenters]
-            </Typography>
-            <Typography
-              color="text.secondary"
-              sx={{ fontSize: 14, maxWidth: 720 }}
-            >
-              First, fill in the boxes below. Then let the coach ask you to
-              clarify the issue you are facing, so that you can describe
-              specifically about (a) what is happening in what context, (b) what
-              you feel about it, (c) what you think will/might happen, and (d)
-              your options. After sorting out the situation and identifying your
-              issue, the presenter and the coach together prepare communication
-              starters.
-            </Typography>
+              <Avatar
+                sx={{
+                  width: 64,
+                  height: 64,
+                  bgcolor: "warning.main",
+                  color: "warning.contrastText",
+                  fontSize: 32,
+                  boxShadow: "0 16px 40px rgba(234, 179, 8, 0.35)",
+                }}
+              >
+                🎤
+              </Avatar>
+              <Box>
+                <Chip
+                  label="Presenter role"
+                  color="warning"
+                  variant="outlined"
+                  size="small"
+                  sx={{
+                    fontWeight: 600,
+                    mb: 1,
+                    bgcolor: "rgba(255,255,255,0.24)",
+                    borderColor: "rgba(253, 186, 116, 0.6)",
+                  }}
+                />
+                <Typography
+                  variant="h4"
+                  sx={{ fontWeight: 800, color: "warning.dark" }}
+                >
+                  Presentation Worksheet
+                </Typography>
+                <Typography
+                  variant="subtitle1"
+                  sx={{ fontWeight: 600, color: "warning.dark", mt: 0.5 }}
+                >
+                  Prepare to lead the conversation with clarity and confidence.
+                </Typography>
+              </Box>
+            </Stack>
+
+            <Divider sx={{ borderColor: "rgba(253, 186, 116, 0.4)" }} />
+
+            <Stack spacing={2}>
+              <Typography
+                color="text.secondary"
+                sx={{ fontSize: 14, maxWidth: 760 }}
+              >
+                First, fill in the boxes below. Then let the coach ask you to
+                clarify the issue you are facing, so that you can describe
+                specifically about (a) what is happening in what context, (b)
+                what you feel about it, (c) what you think will/might happen,
+                and (d) your options. After sorting out the situation and
+                identifying your issue, the presenter and the coach together
+                prepare communication starters.
+              </Typography>
+
+              <Stack
+                direction={{ xs: "column", md: "row" }}
+                spacing={2}
+                sx={{
+                  "& > *": {
+                    flex: 1,
+                  },
+                }}
+              >
+                {headerHighlights.map((highlight) => (
+                  <Box
+                    key={highlight.title}
+                    sx={{
+                      px: 2,
+                      py: 1.5,
+                      borderRadius: 2.5,
+                      border: "1px solid rgba(253, 186, 116, 0.4)",
+                      bgcolor: "rgba(255,255,255,0.28)",
+                      boxShadow: "inset 0 1px 0 rgba(255,255,255,0.35)",
+                      backdropFilter: "blur(6px)",
+                    }}
+                  >
+                    <Typography
+                      variant="subtitle2"
+                      sx={{ fontWeight: 700, color: "warning.dark" }}
+                    >
+                      {highlight.title}
+                    </Typography>
+                    <Typography
+                      variant="body2"
+                      sx={{ color: "text.secondary", mt: 0.5 }}
+                    >
+                      {highlight.description}
+                    </Typography>
+                  </Box>
+                ))}
+              </Stack>
+            </Stack>
           </Stack>
         </Paper>
 


### PR DESCRIPTION
## Summary
- refresh the presenter worksheet hero card with an updated layout, accent visuals, and clearer messaging
- add highlighted guidance boxes that outline the presenter's focus areas before completing the worksheet
- update the coach and observer worksheet headers with role-specific hero cards and guidance highlights

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbc66c2afc8325ad1e3ffda572edf9