### PR TITLE
Polish home dashboard experience

### DIFF
--- a/src/app/(protected)/_components/next-session-card.tsx
+++ b/src/app/(protected)/_components/next-session-card.tsx
@@ -13,6 +13,7 @@ import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
 import CardContent from "@mui/material/CardContent";
+import Chip from "@mui/material/Chip";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
@@ -216,7 +217,17 @@ export function NextSessionCard({
         }}
       >
         <Stack spacing={3}>
-          <Stack spacing={1}>
+          <Stack spacing={1.5}>
+            <Chip
+              label={normalized.startAt ? "Upcoming" : "Set the date"}
+              color="primary"
+              size="small"
+              sx={{
+                alignSelf: "flex-start",
+                fontWeight: 600,
+                letterSpacing: "0.12em",
+              }}
+            />
             <Typography variant="h4" component="h2" sx={{ fontWeight: 700 }}>
               Next Session
             </Typography>
@@ -277,14 +288,32 @@ export function NextSessionCard({
           zIndex: 1,
         }}
       >
-        <Button
-          variant="contained"
-          onClick={openDialog}
-          disabled={isPending}
-          fullWidth
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={1.5}
+          sx={{ width: "100%" }}
         >
-          Edit details
-        </Button>
+          {locationIsUrl ? (
+            <Button
+              component="a"
+              href={locationValue}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="outlined"
+              fullWidth
+            >
+              Open location
+            </Button>
+          ) : null}
+          <Button
+            variant="contained"
+            onClick={openDialog}
+            disabled={isPending}
+            fullWidth
+          >
+            Edit details
+          </Button>
+        </Stack>
       </CardActions>
 
       <Dialog open={dialogOpen} onClose={handleClose} fullWidth maxWidth="sm">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,13 +3,24 @@ import { getOptionalUserSession } from "@/lib/session";
 import { getNextSession } from "@/lib/turso";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
 import Card from "@mui/material/Card";
 import Container from "@mui/material/Container";
 import Divider from "@mui/material/Divider";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Unstable_Grid2";
 import Link from "next/link";
+import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
+import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
+import DashboardRoundedIcon from "@mui/icons-material/DashboardRounded";
+import ForumRoundedIcon from "@mui/icons-material/ForumRounded";
+import MenuBookRoundedIcon from "@mui/icons-material/MenuBookRounded";
+import RocketLaunchRoundedIcon from "@mui/icons-material/RocketLaunchRounded";
 
 // Force dynamic rendering - no caching
 export const dynamic = 'force-dynamic';
@@ -45,7 +56,23 @@ export default async function Home() {
   const firstName = user?.name?.split(" ")[0] ?? "Member";
 
   return (
-    <Box sx={{ bgcolor: "#FFFFFF", minHeight: "100vh" }}>
+    <Box
+      sx={{
+        bgcolor: "#FFFFFF",
+        minHeight: "100vh",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        sx={{
+          position: "absolute",
+          inset: 0,
+          pointerEvents: "none",
+          background:
+            "radial-gradient(120% 120% at 100% 0%, rgba(0, 51, 102, 0.08) 0%, transparent 55%), radial-gradient(80% 80% at 0% 100%, rgba(230, 0, 18, 0.08) 0%, transparent 60%)",
+        }}
+      />
       <Container
         maxWidth="lg"
         sx={{
@@ -66,9 +93,18 @@ export default async function Home() {
             </Grid>
             <Grid xs={1} md={7} order={{ xs: 2, md: 1 }}>
               <Stack
-                spacing={{ xs: 2, sm: 2.5, md: 3 }}
+                spacing={{ xs: 2, sm: 2.5, md: 3.5 }}
                 sx={{ textAlign: { xs: "center", md: "left" } }}
               >
+                <Chip
+                  label="Goen Net circle workspace"
+                  color="primary"
+                  sx={{
+                    alignSelf: { xs: "center", md: "flex-start" },
+                    fontWeight: 600,
+                    letterSpacing: "0.08em",
+                  }}
+                />
                 <Typography
                   variant="overline"
                   sx={{
@@ -105,7 +141,169 @@ export default async function Home() {
                   move the circle forward. Start by reviewing your peers&apos; latest
                   updates so everyone arrives ready for the conversation.
                 </Typography>
+                <Stack
+                  direction={{ xs: "column", sm: "row" }}
+                  spacing={{ xs: 1.5, sm: 2 }}
+                  justifyContent={{ xs: "center", md: "flex-start" }}
+                >
+                  <Button
+                    component={Link}
+                    href="/updates"
+                    variant="contained"
+                    size="large"
+                    sx={{ px: 4 }}
+                  >
+                    Review updates
+                  </Button>
+                  <Button
+                    component={Link}
+                    href="/prioritization"
+                    variant="outlined"
+                    size="large"
+                    sx={{
+                      px: 4,
+                      borderColor: "rgba(0, 51, 102, 0.35)",
+                      color: "primary.main",
+                      "&:hover": {
+                        borderColor: "primary.main",
+                        bgcolor: "rgba(0, 51, 102, 0.04)",
+                      },
+                    }}
+                  >
+                    Open agenda board
+                  </Button>
+                </Stack>
               </Stack>
+            </Grid>
+          </Grid>
+
+          <Grid
+            container
+            columns={{ xs: 1, md: 12 }}
+            columnSpacing={{ xs: 0, md: 3 }}
+            rowSpacing={{ xs: 2.5, md: 3 }}
+          >
+            <Grid xs={1} md={8}>
+              <Card sx={{ p: { xs: 2.5, md: 3 }, height: "100%" }}>
+                <Stack spacing={2.5}>
+                  <Stack
+                    direction="row"
+                    spacing={1.5}
+                    alignItems="center"
+                    justifyContent="space-between"
+                  >
+                    <Typography
+                      variant="overline"
+                      color="primary"
+                      sx={{ letterSpacing: "0.18em" }}
+                    >
+                      Quick prep
+                    </Typography>
+                    <Chip label="5 min" size="small" sx={{ fontWeight: 600 }} />
+                  </Stack>
+                  <Typography variant="h5" sx={{ fontWeight: 600 }}>
+                    Checklist before you join
+                  </Typography>
+                  <List disablePadding sx={{ display: "grid", gap: 1.5 }}>
+                    {[ 
+                      {
+                        primary: "Skim everyone&apos;s latest update",
+                        secondary:
+                          "Highlight the wins, blockers, and follow-ups that matter most.",
+                      },
+                      {
+                        primary: "Vote on the conversations that need airtime",
+                        secondary:
+                          "Stack rank the agenda so facilitators can set the flow with confidence.",
+                      },
+                      {
+                        primary: "Log any context teammates should review",
+                        secondary:
+                          "Attach links, decks, or docs so decisions can happen in the room.",
+                      },
+                    ].map((item) => (
+                      <ListItem
+                        key={item.primary}
+                        sx={{
+                          borderRadius: 2,
+                          px: 1.5,
+                          py: 1.25,
+                          bgcolor: "rgba(0, 51, 102, 0.04)",
+                        }}
+                      >
+                        <ListItemIcon sx={{ minWidth: 36 }}>
+                          <CheckCircleRoundedIcon sx={{ color: "primary.main" }} />
+                        </ListItemIcon>
+                        <ListItemText
+                          primaryTypographyProps={{ fontWeight: 600 }}
+                          secondaryTypographyProps={{ color: "text.secondary" }}
+                          primary={item.primary}
+                          secondary={item.secondary}
+                        />
+                      </ListItem>
+                    ))}
+                  </List>
+                </Stack>
+              </Card>
+            </Grid>
+            <Grid xs={1} md={4}>
+              <Card
+                sx={{
+                  p: { xs: 2.5, md: 3 },
+                  position: "relative",
+                  overflow: "hidden",
+                  bgcolor: "#021f3f",
+                  color: "common.white",
+                  height: "100%",
+                }}
+              >
+                <Box
+                  sx={{
+                    position: "absolute",
+                    inset: 0,
+                    background:
+                      "radial-gradient(circle at 15% 15%, rgba(255, 255, 255, 0.18), transparent 55%), radial-gradient(circle at 85% 85%, rgba(230,0,18,0.3), transparent 65%)",
+                    opacity: 0.9,
+                  }}
+                />
+                <Stack spacing={2.5} sx={{ position: "relative", zIndex: 1 }}>
+                  <Stack direction="row" spacing={1.5} alignItems="center">
+                    <RocketLaunchRoundedIcon />
+                    <Typography
+                      variant="overline"
+                      sx={{ letterSpacing: "0.18em", color: "rgba(255,255,255,0.8)" }}
+                    >
+                      Facilitator tip
+                    </Typography>
+                  </Stack>
+                  <Typography variant="h5" sx={{ fontWeight: 600 }}>
+                    Spin up a ten-minute huddle
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.8)" }}>
+                    Kick off a quick sync with the prioritization board to confirm
+                    the running order and capture any last-minute decisions before
+                    the session.
+                  </Typography>
+                  <Button
+                    component={Link}
+                    href="/prioritization"
+                    variant="outlined"
+                    size="large"
+                    sx={{
+                      alignSelf: { xs: "flex-start", md: "flex-start" },
+                      borderColor: "rgba(255,255,255,0.6)",
+                      color: "common.white",
+                      fontWeight: 600,
+                      "&:hover": {
+                        borderColor: "common.white",
+                        bgcolor: "rgba(255,255,255,0.08)",
+                      },
+                    }}
+                  >
+                    Launch board
+                  </Button>
+                </Stack>
+              </Card>
             </Grid>
           </Grid>
 
@@ -142,6 +340,21 @@ export default async function Home() {
               >
                 <Grid xs={1} md={4}>
                   <Stack spacing={1}>
+                    <Box
+                      sx={{
+                        width: 48,
+                        height: 48,
+                        borderRadius: 2.5,
+                        display: "inline-flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        bgcolor: "rgba(0, 51, 102, 0.08)",
+                        color: "primary.main",
+                        mb: 1,
+                      }}
+                    >
+                      <ForumRoundedIcon />
+                    </Box>
                     <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
                       Share signal-rich updates
                     </Typography>
@@ -154,6 +367,21 @@ export default async function Home() {
                 </Grid>
                 <Grid xs={1} md={4}>
                   <Stack spacing={1}>
+                    <Box
+                      sx={{
+                        width: 48,
+                        height: 48,
+                        borderRadius: 2.5,
+                        display: "inline-flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        bgcolor: "rgba(0, 51, 102, 0.08)",
+                        color: "primary.main",
+                        mb: 1,
+                      }}
+                    >
+                      <DashboardRoundedIcon />
+                    </Box>
                     <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
                       Shape the agenda together
                     </Typography>
@@ -165,6 +393,21 @@ export default async function Home() {
                 </Grid>
                 <Grid xs={1} md={4}>
                   <Stack spacing={1}>
+                    <Box
+                      sx={{
+                        width: 48,
+                        height: 48,
+                        borderRadius: 2.5,
+                        display: "inline-flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        bgcolor: "rgba(0, 51, 102, 0.08)",
+                        color: "primary.main",
+                        mb: 1,
+                      }}
+                    >
+                      <AccessTimeRoundedIcon />
+                    </Box>
                     <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
                       Capture commitments automatically
                     </Typography>
@@ -315,6 +558,21 @@ export default async function Home() {
             <Grid xs={1} md={4}>
               <Card sx={{ height: "100%", p: { xs: 2, sm: 2.5, md: 3 } }}>
                 <Stack spacing={1.5}>
+                  <Box
+                    sx={{
+                      width: 48,
+                      height: 48,
+                      borderRadius: 2.5,
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      bgcolor: "rgba(0, 51, 102, 0.08)",
+                      color: "primary.main",
+                      boxShadow: "0 12px 26px rgba(0, 44, 95, 0.1)",
+                    }}
+                  >
+                    <ForumRoundedIcon />
+                  </Box>
                   <Typography
                     variant="overline"
                     color="primary"
@@ -344,6 +602,21 @@ export default async function Home() {
             <Grid xs={1} md={4}>
               <Card sx={{ height: "100%", p: { xs: 2, sm: 2.5, md: 3 } }}>
                 <Stack spacing={1.5}>
+                  <Box
+                    sx={{
+                      width: 48,
+                      height: 48,
+                      borderRadius: 2.5,
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      bgcolor: "rgba(0, 51, 102, 0.08)",
+                      color: "primary.main",
+                      boxShadow: "0 12px 26px rgba(0, 44, 95, 0.1)",
+                    }}
+                  >
+                    <DashboardRoundedIcon />
+                  </Box>
                   <Typography
                     variant="overline"
                     color="primary"
@@ -372,6 +645,21 @@ export default async function Home() {
             <Grid xs={1} md={4}>
               <Card sx={{ height: "100%", p: { xs: 2, sm: 2.5, md: 3 } }}>
                 <Stack spacing={1.5}>
+                  <Box
+                    sx={{
+                      width: 48,
+                      height: 48,
+                      borderRadius: 2.5,
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      bgcolor: "rgba(0, 51, 102, 0.08)",
+                      color: "primary.main",
+                      boxShadow: "0 12px 26px rgba(0, 44, 95, 0.1)",
+                    }}
+                  >
+                    <MenuBookRoundedIcon />
+                  </Box>
                   <Typography
                     variant="overline"
                     color="primary"


### PR DESCRIPTION
## Summary
- enrich the home dashboard hero with a workspace chip, clear calls-to-action, and subtle background gradients
- add a quick prep checklist and facilitator tip cards to guide members before each session
- refresh the next session card with an "Upcoming" status chip and a direct launch button for virtual locations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbcb4d615083259a51c05a9c79d8f1