### PR TITLE
Simplify coach worksheet storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "autoprefixer": "^10.4.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "crypto-js": "^4.2.0",
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.2",
         "framer-motion": "^12.23.22",
@@ -5096,6 +5097,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-tree": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "autoprefixer": "^10.4.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "crypto-js": "^4.2.0",
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.2",
     "framer-motion": "^12.23.22",

--- a/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
@@ -16,215 +16,30 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import AES from "crypto-js/aes";
+import Utf8 from "crypto-js/enc-utf8";
 import type { ChangeEvent } from "react";
 import { useMemo, useState, useEffect } from "react";
 
 const STORAGE_KEY = "worksheet_coach_v1";
-const ENC_VERSION = "v2";
-const IV_BYTES = 12;
-const KEY_DB_NAME = "coachWorksheetSecureStore";
-const KEY_STORE_NAME = "keys";
-const KEY_ID = "coachWorksheetKey_v1";
+const encryptFormData = (form: CoachForm, passphrase: string): string =>
+  AES.encrypt(JSON.stringify(form), passphrase).toString();
 
-const isSecureStorageAvailable = () =>
-  typeof window !== "undefined" &&
-  Boolean(window.crypto?.subtle) &&
-  typeof window.indexedDB !== "undefined";
-
-const toBase64 = (value: Uint8Array): string => {
-  if (typeof window !== "undefined" && typeof window.btoa === "function") {
-    let binary = "";
-    value.forEach((byte) => {
-      binary += String.fromCharCode(byte);
-    });
-    return window.btoa(binary);
-  }
-  if (typeof Buffer !== "undefined") {
-    return Buffer.from(value).toString("base64");
-  }
-  throw new Error("Base64 encoding is not supported in this environment.");
-};
-
-const fromBase64 = (encoded: string): Uint8Array => {
-  if (typeof window !== "undefined" && typeof window.atob === "function") {
-    const binary = window.atob(encoded);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i += 1) {
-      bytes[i] = binary.charCodeAt(i);
-    }
-    return bytes;
-  }
-  if (typeof Buffer !== "undefined") {
-    return new Uint8Array(Buffer.from(encoded, "base64"));
-  }
-  throw new Error("Base64 decoding is not supported in this environment.");
-};
-
-function openKeyDatabase(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    if (typeof window === "undefined") {
-      reject(new Error("Secure storage is not available on the server."));
-      return;
-    }
-
-    const request = window.indexedDB.open(KEY_DB_NAME, 1);
-
-    request.onupgradeneeded = () => {
-      request.result.createObjectStore(KEY_STORE_NAME);
-    };
-
-    request.onsuccess = () => {
-      resolve(request.result);
-    };
-
-    request.onerror = () => {
-      reject(request.error ?? new Error("Failed to open secure storage."));
-    };
-  });
-}
-
-async function getStoredKey(): Promise<CryptoKey | null> {
+const decryptFormData = (
+  record: string,
+  passphrase: string
+): CoachForm | null => {
   try {
-    const db = await openKeyDatabase();
-    return await new Promise((resolve, reject) => {
-      const transaction = db.transaction(KEY_STORE_NAME, "readonly");
-      const store = transaction.objectStore(KEY_STORE_NAME);
-      const getRequest = store.get(KEY_ID);
-
-      getRequest.onsuccess = () => {
-        resolve((getRequest.result as CryptoKey | undefined) ?? null);
-      };
-
-      getRequest.onerror = () => {
-        reject(getRequest.error ?? new Error("Failed to read secure key."));
-      };
-
-      transaction.oncomplete = () => {
-        db.close();
-      };
-
-      transaction.onerror = () => {
-        reject(transaction.error ?? new Error("Secure key transaction failed."));
-      };
-    });
-  } catch (error) {
-    console.warn("Failed to access coach worksheet key", error);
-    return null;
-  }
-}
-
-async function storeKey(key: CryptoKey): Promise<void> {
-  const db = await openKeyDatabase();
-  await new Promise<void>((resolve, reject) => {
-    const transaction = db.transaction(KEY_STORE_NAME, "readwrite");
-    const store = transaction.objectStore(KEY_STORE_NAME);
-    store.put(key, KEY_ID);
-
-    transaction.oncomplete = () => {
-      db.close();
-      resolve();
-    };
-
-    transaction.onerror = () => {
-      reject(transaction.error ?? new Error("Failed to persist secure key."));
-    };
-  });
-}
-
-async function deleteStoredKey(): Promise<void> {
-  try {
-    const db = await openKeyDatabase();
-    await new Promise<void>((resolve, reject) => {
-      const transaction = db.transaction(KEY_STORE_NAME, "readwrite");
-      const store = transaction.objectStore(KEY_STORE_NAME);
-      store.delete(KEY_ID);
-
-      transaction.oncomplete = () => {
-        db.close();
-        resolve();
-      };
-
-      transaction.onerror = () => {
-        reject(transaction.error ?? new Error("Failed to remove secure key."));
-      };
-    });
-  } catch (error) {
-    console.warn("Failed to remove coach worksheet key", error);
-  }
-}
-
-async function generateAndStoreKey(): Promise<CryptoKey> {
-  if (typeof window === "undefined" || !window.crypto?.subtle) {
-    throw new Error("Secure storage is not supported in this environment.");
-  }
-
-  const key = await window.crypto.subtle.generateKey(
-    { name: "AES-GCM", length: 256 },
-    false,
-    ["encrypt", "decrypt"]
-  );
-
-  await storeKey(key);
-  return key;
-}
-
-async function getOrCreateKey(): Promise<CryptoKey> {
-  const existing = await getStoredKey();
-  if (existing) {
-    return existing;
-  }
-  return generateAndStoreKey();
-}
-
-async function encryptFormData(form: CoachForm): Promise<string> {
-  if (typeof window === "undefined" || !window.crypto?.subtle) {
-    throw new Error("Secure storage is not supported in this environment.");
-  }
-
-  const key = await getOrCreateKey();
-  const iv = window.crypto.getRandomValues(new Uint8Array(IV_BYTES));
-  const encoder = new TextEncoder();
-  const payload = encoder.encode(JSON.stringify(form));
-  const encrypted = await window.crypto.subtle.encrypt(
-    { name: "AES-GCM", iv: iv.buffer as ArrayBuffer },
-    key,
-    payload
-  );
-
-  return [ENC_VERSION, toBase64(iv), toBase64(new Uint8Array(encrypted))].join(":");
-}
-
-async function decryptFormData(record: string): Promise<CoachForm | null> {
-  if (typeof window === "undefined" || !window.crypto?.subtle) {
-    return null;
-  }
-
-  try {
-    const [version, ivEncoded, payloadEncoded] = record.split(":");
-    if (version !== ENC_VERSION || !ivEncoded || !payloadEncoded) {
+    const decrypted = AES.decrypt(record, passphrase).toString(Utf8);
+    if (!decrypted) {
       return null;
     }
-
-    const key = await getStoredKey();
-    if (!key) {
-      return null;
-    }
-
-    const iv = fromBase64(ivEncoded);
-    const payload = fromBase64(payloadEncoded);
-    const decrypted = await window.crypto.subtle.decrypt(
-      { name: "AES-GCM", iv: iv.buffer as ArrayBuffer },
-      key,
-      payload.buffer as ArrayBuffer
-    );
-    const decoder = new TextDecoder();
-    const json = decoder.decode(decrypted);
-    return JSON.parse(json) as CoachForm;
+    return JSON.parse(decrypted) as CoachForm;
   } catch (error) {
     console.warn("Failed to decrypt coach worksheet", error);
     return null;
   }
-}
+};
 
 type ConfidentialLevel = "HIGH" | "MEDIUM" | "NORMAL" | "";
 
@@ -245,71 +60,29 @@ type ChangeHandler = (
 export function CoachWorksheet() {
   useDocumentTitle("Coach Worksheet");
   const [form, setForm] = useState<CoachForm>({});
-  const [initializing, setInitializing] = useState(true);
-  const [secureStorageSupported, setSecureStorageSupported] = useState(false);
   const [hasSavedData, setHasSavedData] = useState(false);
+  const [encryptedRecord, setEncryptedRecord] = useState<string | null>(null);
+  const [passphrase, setPassphrase] = useState("");
   const [saveStatus, setSaveStatus] = useState<{
     type: "success" | "error";
     message: string;
   } | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const [unlockStatus, setUnlockStatus] = useState<{
+    type: "success" | "error";
+    message: string;
+  } | null>(null);
   const [saving, setSaving] = useState(false);
   const [clearing, setClearing] = useState(false);
+  const [unlocking, setUnlocking] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
 
-    let active = true;
-
-    const initialize = async () => {
-      const supported = isSecureStorageAvailable();
-      if (!active) return;
-      setSecureStorageSupported(supported);
-
-      const record = window.localStorage.getItem(STORAGE_KEY);
-      if (!active) return;
-      setHasSavedData(Boolean(record));
-
-      if (!supported) {
-        setLoadError(
-          "Secure storage is not supported in this browser. Notes cannot be saved."
-        );
-        setInitializing(false);
-        return;
-      }
-
-      if (!record) {
-        setInitializing(false);
-        return;
-      }
-
-      const decrypted = await decryptFormData(record);
-      if (!active) return;
-
-      if (decrypted) {
-        setForm(decrypted);
-        setLoadError(null);
-      } else {
-        setLoadError(
-          "Saved notes could not be unlocked. They may have been created on another device or have been cleared."
-        );
-      }
-
-      setInitializing(false);
-    };
-
-    initialize().catch((error) => {
-      console.warn("Failed to load coach worksheet", error);
-      if (!active) return;
-      setLoadError("Unable to load saved notes right now.");
-      setInitializing(false);
-    });
-
-    return () => {
-      active = false;
-    };
+    const record = window.localStorage.getItem(STORAGE_KEY);
+    setEncryptedRecord(record);
+    setHasSavedData(Boolean(record));
   }, []);
 
   const handleChange: ChangeHandler = (key) => (event) => {
@@ -321,7 +94,7 @@ export function CoachWorksheet() {
       [key]: value,
     }));
     setSaveStatus(null);
-    setLoadError(null);
+    setUnlockStatus(null);
   };
 
   const handleConfidentialChange = (level: ConfidentialLevel) => () => {
@@ -330,29 +103,30 @@ export function CoachWorksheet() {
       confidential: prev.confidential === level ? "" : level,
     }));
     setSaveStatus(null);
-    setLoadError(null);
+    setUnlockStatus(null);
   };
 
   const handleSave = async () => {
-    if (typeof window === "undefined" || initializing) return;
+    if (typeof window === "undefined") return;
 
-    if (!secureStorageSupported) {
+    if (!passphrase) {
       setSaveStatus({
         type: "error",
         message:
-          "Secure storage is not available in this browser, so notes cannot be saved.",
+          "Enter a passphrase to encrypt your notes before saving them to this device.",
       });
       return;
     }
 
     setSaving(true);
     setSaveStatus(null);
+    setUnlockStatus(null);
 
     try {
-      const encrypted = await encryptFormData(form);
+      const encrypted = encryptFormData(form, passphrase);
       window.localStorage.setItem(STORAGE_KEY, encrypted);
+      setEncryptedRecord(encrypted);
       setHasSavedData(true);
-      setLoadError(null);
       setSaveStatus({
         type: "success",
         message: "Saved encrypted notes to this device.",
@@ -369,7 +143,7 @@ export function CoachWorksheet() {
   };
 
   const handleClear = async () => {
-    if (typeof window === "undefined" || initializing) return;
+    if (typeof window === "undefined") return;
     if (!window.confirm("Clear all saved inputs for Coach worksheet?")) return;
 
     setClearing(true);
@@ -378,17 +152,60 @@ export function CoachWorksheet() {
       window.localStorage.removeItem(STORAGE_KEY);
       setForm({});
       setHasSavedData(false);
-      setLoadError(null);
+      setEncryptedRecord(null);
+      setUnlockStatus(null);
       setSaveStatus({
         type: "success",
         message: "Saved notes have been removed from this device.",
       });
-      if (secureStorageSupported) {
-        await deleteStoredKey();
-      }
     } finally {
       setClearing(false);
     }
+  };
+
+  const handleUnlock = () => {
+    if (typeof window === "undefined" || !encryptedRecord) {
+      return;
+    }
+
+    if (!passphrase) {
+      setUnlockStatus({
+        type: "error",
+        message: "Enter the passphrase used when saving your notes to unlock them.",
+      });
+      return;
+    }
+
+    setUnlocking(true);
+    setUnlockStatus(null);
+    setSaveStatus(null);
+
+    try {
+      const decrypted = decryptFormData(encryptedRecord, passphrase);
+      if (!decrypted) {
+        setUnlockStatus({
+          type: "error",
+          message: "Unable to unlock saved notes. Double-check the passphrase.",
+        });
+        return;
+      }
+
+      setForm(decrypted);
+      setUnlockStatus({
+        type: "success",
+        message: "Unlocked saved notes for this session.",
+      });
+    } finally {
+      setUnlocking(false);
+    }
+  };
+
+  const handlePassphraseChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setPassphrase(event.target.value);
+    setSaveStatus(null);
+    setUnlockStatus(null);
   };
 
   const issueTypeChecks = useMemo(
@@ -861,9 +678,19 @@ export function CoachWorksheet() {
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 Save your progress to this device so you can revisit and edit
-                it later. Saved notes stay only on this browser.
+                it later. Saved notes stay only on this browser. Protect them
+                with a passphrase so they remain encrypted at rest.
               </Typography>
             </Stack>
+
+            <TextField
+              label="Passphrase"
+              type="password"
+              value={passphrase}
+              onChange={handlePassphraseChange}
+              placeholder="Enter a passphrase to encrypt your notes"
+              helperText="Use the same passphrase to unlock saved notes on this device."
+            />
 
             <Stack
               direction={{ xs: "column", sm: "row" }}
@@ -871,9 +698,16 @@ export function CoachWorksheet() {
               justifyContent="flex-end"
             >
               <Button
+                variant="outlined"
+                onClick={handleUnlock}
+                disabled={!hasSavedData || unlocking}
+              >
+                {unlocking ? "Unlocking..." : "Unlock saved notes"}
+              </Button>
+              <Button
                 variant="contained"
                 onClick={handleSave}
-                disabled={initializing || saving || !secureStorageSupported}
+                disabled={saving}
               >
                 {saving ? "Saving..." : "Save"}
               </Button>
@@ -881,15 +715,22 @@ export function CoachWorksheet() {
                 variant="outlined"
                 color="warning"
                 onClick={handleClear}
-                disabled={initializing || clearing || !hasSavedData}
+                disabled={clearing || !hasSavedData}
               >
                 {clearing ? "Clearing..." : "Clear"}
               </Button>
             </Stack>
 
-            {loadError ? (
-              <Typography color="error.main" variant="body2">
-                {loadError}
+            {unlockStatus ? (
+              <Typography
+                color={
+                  unlockStatus.type === "success"
+                    ? "success.main"
+                    : "error.main"
+                }
+                variant="body2"
+              >
+                {unlockStatus.message}
               </Typography>
             ) : null}
             {saveStatus ? (

--- a/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
@@ -17,22 +17,212 @@ import {
   Typography,
 } from "@mui/material";
 import type { ChangeEvent } from "react";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 
 const STORAGE_KEY = "worksheet_coach_v1";
+const ENC_VERSION = "v2";
+const IV_BYTES = 12;
+const KEY_DB_NAME = "coachWorksheetSecureStore";
+const KEY_STORE_NAME = "keys";
+const KEY_ID = "coachWorksheetKey_v1";
 
-function readInitialForm(): CoachForm {
-  if (typeof window === "undefined") {
-    return {};
+const isSecureStorageAvailable = () =>
+  typeof window !== "undefined" &&
+  Boolean(window.crypto?.subtle) &&
+  typeof window.indexedDB !== "undefined";
+
+const toBase64 = (value: Uint8Array): string => {
+  if (typeof window !== "undefined" && typeof window.btoa === "function") {
+    let binary = "";
+    value.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return window.btoa(binary);
+  }
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value).toString("base64");
+  }
+  throw new Error("Base64 encoding is not supported in this environment.");
+};
+
+const fromBase64 = (encoded: string): Uint8Array => {
+  if (typeof window !== "undefined" && typeof window.atob === "function") {
+    const binary = window.atob(encoded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  if (typeof Buffer !== "undefined") {
+    return new Uint8Array(Buffer.from(encoded, "base64"));
+  }
+  throw new Error("Base64 decoding is not supported in this environment.");
+};
+
+function openKeyDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof window === "undefined") {
+      reject(new Error("Secure storage is not available on the server."));
+      return;
+    }
+
+    const request = window.indexedDB.open(KEY_DB_NAME, 1);
+
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(KEY_STORE_NAME);
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+
+    request.onerror = () => {
+      reject(request.error ?? new Error("Failed to open secure storage."));
+    };
+  });
+}
+
+async function getStoredKey(): Promise<CryptoKey | null> {
+  try {
+    const db = await openKeyDatabase();
+    return await new Promise((resolve, reject) => {
+      const transaction = db.transaction(KEY_STORE_NAME, "readonly");
+      const store = transaction.objectStore(KEY_STORE_NAME);
+      const getRequest = store.get(KEY_ID);
+
+      getRequest.onsuccess = () => {
+        resolve((getRequest.result as CryptoKey | undefined) ?? null);
+      };
+
+      getRequest.onerror = () => {
+        reject(getRequest.error ?? new Error("Failed to read secure key."));
+      };
+
+      transaction.oncomplete = () => {
+        db.close();
+      };
+
+      transaction.onerror = () => {
+        reject(transaction.error ?? new Error("Secure key transaction failed."));
+      };
+    });
+  } catch (error) {
+    console.warn("Failed to access coach worksheet key", error);
+    return null;
+  }
+}
+
+async function storeKey(key: CryptoKey): Promise<void> {
+  const db = await openKeyDatabase();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(KEY_STORE_NAME, "readwrite");
+    const store = transaction.objectStore(KEY_STORE_NAME);
+    store.put(key, KEY_ID);
+
+    transaction.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+
+    transaction.onerror = () => {
+      reject(transaction.error ?? new Error("Failed to persist secure key."));
+    };
+  });
+}
+
+async function deleteStoredKey(): Promise<void> {
+  try {
+    const db = await openKeyDatabase();
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(KEY_STORE_NAME, "readwrite");
+      const store = transaction.objectStore(KEY_STORE_NAME);
+      store.delete(KEY_ID);
+
+      transaction.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+
+      transaction.onerror = () => {
+        reject(transaction.error ?? new Error("Failed to remove secure key."));
+      };
+    });
+  } catch (error) {
+    console.warn("Failed to remove coach worksheet key", error);
+  }
+}
+
+async function generateAndStoreKey(): Promise<CryptoKey> {
+  if (typeof window === "undefined" || !window.crypto?.subtle) {
+    throw new Error("Secure storage is not supported in this environment.");
+  }
+
+  const key = await window.crypto.subtle.generateKey(
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"]
+  );
+
+  await storeKey(key);
+  return key;
+}
+
+async function getOrCreateKey(): Promise<CryptoKey> {
+  const existing = await getStoredKey();
+  if (existing) {
+    return existing;
+  }
+  return generateAndStoreKey();
+}
+
+async function encryptFormData(form: CoachForm): Promise<string> {
+  if (typeof window === "undefined" || !window.crypto?.subtle) {
+    throw new Error("Secure storage is not supported in this environment.");
+  }
+
+  const key = await getOrCreateKey();
+  const iv = window.crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const encoder = new TextEncoder();
+  const payload = encoder.encode(JSON.stringify(form));
+  const encrypted = await window.crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: iv.buffer as ArrayBuffer },
+    key,
+    payload
+  );
+
+  return [ENC_VERSION, toBase64(iv), toBase64(new Uint8Array(encrypted))].join(":");
+}
+
+async function decryptFormData(record: string): Promise<CoachForm | null> {
+  if (typeof window === "undefined" || !window.crypto?.subtle) {
+    return null;
   }
 
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return {};
-    return JSON.parse(raw) as CoachForm;
+    const [version, ivEncoded, payloadEncoded] = record.split(":");
+    if (version !== ENC_VERSION || !ivEncoded || !payloadEncoded) {
+      return null;
+    }
+
+    const key = await getStoredKey();
+    if (!key) {
+      return null;
+    }
+
+    const iv = fromBase64(ivEncoded);
+    const payload = fromBase64(payloadEncoded);
+    const decrypted = await window.crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: iv.buffer as ArrayBuffer },
+      key,
+      payload.buffer as ArrayBuffer
+    );
+    const decoder = new TextDecoder();
+    const json = decoder.decode(decrypted);
+    return JSON.parse(json) as CoachForm;
   } catch (error) {
-    console.warn("Failed to parse coach worksheet state", error);
-    return {};
+    console.warn("Failed to decrypt coach worksheet", error);
+    return null;
   }
 }
 
@@ -54,11 +244,73 @@ type ChangeHandler = (
 
 export function CoachWorksheet() {
   useDocumentTitle("Coach Worksheet");
-  const [form, setForm] = useState<CoachForm>(() => readInitialForm());
+  const [form, setForm] = useState<CoachForm>({});
+  const [initializing, setInitializing] = useState(true);
+  const [secureStorageSupported, setSecureStorageSupported] = useState(false);
+  const [hasSavedData, setHasSavedData] = useState(false);
   const [saveStatus, setSaveStatus] = useState<{
     type: "success" | "error";
     message: string;
   } | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [clearing, setClearing] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    let active = true;
+
+    const initialize = async () => {
+      const supported = isSecureStorageAvailable();
+      if (!active) return;
+      setSecureStorageSupported(supported);
+
+      const record = window.localStorage.getItem(STORAGE_KEY);
+      if (!active) return;
+      setHasSavedData(Boolean(record));
+
+      if (!supported) {
+        setLoadError(
+          "Secure storage is not supported in this browser. Notes cannot be saved."
+        );
+        setInitializing(false);
+        return;
+      }
+
+      if (!record) {
+        setInitializing(false);
+        return;
+      }
+
+      const decrypted = await decryptFormData(record);
+      if (!active) return;
+
+      if (decrypted) {
+        setForm(decrypted);
+        setLoadError(null);
+      } else {
+        setLoadError(
+          "Saved notes could not be unlocked. They may have been created on another device or have been cleared."
+        );
+      }
+
+      setInitializing(false);
+    };
+
+    initialize().catch((error) => {
+      console.warn("Failed to load coach worksheet", error);
+      if (!active) return;
+      setLoadError("Unable to load saved notes right now.");
+      setInitializing(false);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const handleChange: ChangeHandler = (key) => (event) => {
     const target = event.target as HTMLInputElement;
@@ -69,6 +321,7 @@ export function CoachWorksheet() {
       [key]: value,
     }));
     setSaveStatus(null);
+    setLoadError(null);
   };
 
   const handleConfidentialChange = (level: ConfidentialLevel) => () => {
@@ -77,16 +330,32 @@ export function CoachWorksheet() {
       confidential: prev.confidential === level ? "" : level,
     }));
     setSaveStatus(null);
+    setLoadError(null);
   };
 
-  const handleSave = () => {
-    if (typeof window === "undefined") return;
+  const handleSave = async () => {
+    if (typeof window === "undefined" || initializing) return;
+
+    if (!secureStorageSupported) {
+      setSaveStatus({
+        type: "error",
+        message:
+          "Secure storage is not available in this browser, so notes cannot be saved.",
+      });
+      return;
+    }
+
+    setSaving(true);
+    setSaveStatus(null);
 
     try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(form));
+      const encrypted = await encryptFormData(form);
+      window.localStorage.setItem(STORAGE_KEY, encrypted);
+      setHasSavedData(true);
+      setLoadError(null);
       setSaveStatus({
         type: "success",
-        message: "Saved notes to this device.",
+        message: "Saved encrypted notes to this device.",
       });
     } catch (error) {
       console.warn("Failed to persist coach worksheet", error);
@@ -94,18 +363,32 @@ export function CoachWorksheet() {
         type: "error",
         message: "Failed to save notes. Please try again.",
       });
+    } finally {
+      setSaving(false);
     }
   };
 
-  const handleClear = () => {
-    if (typeof window === "undefined") return;
+  const handleClear = async () => {
+    if (typeof window === "undefined" || initializing) return;
     if (!window.confirm("Clear all saved inputs for Coach worksheet?")) return;
-    window.localStorage.removeItem(STORAGE_KEY);
-    setForm({});
-    setSaveStatus({
-      type: "success",
-      message: "Saved notes have been removed from this device.",
-    });
+
+    setClearing(true);
+
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+      setForm({});
+      setHasSavedData(false);
+      setLoadError(null);
+      setSaveStatus({
+        type: "success",
+        message: "Saved notes have been removed from this device.",
+      });
+      if (secureStorageSupported) {
+        await deleteStoredKey();
+      }
+    } finally {
+      setClearing(false);
+    }
   };
 
   const issueTypeChecks = useMemo(
@@ -590,14 +873,25 @@ export function CoachWorksheet() {
               <Button
                 variant="contained"
                 onClick={handleSave}
+                disabled={initializing || saving || !secureStorageSupported}
               >
-                Save
+                {saving ? "Saving..." : "Save"}
               </Button>
-              <Button variant="outlined" color="warning" onClick={handleClear}>
-                Clear
+              <Button
+                variant="outlined"
+                color="warning"
+                onClick={handleClear}
+                disabled={initializing || clearing || !hasSavedData}
+              >
+                {clearing ? "Clearing..." : "Clear"}
               </Button>
             </Stack>
 
+            {loadError ? (
+              <Typography color="error.main" variant="body2">
+                {loadError}
+              </Typography>
+            ) : null}
             {saveStatus ? (
               <Typography
                 color={

--- a/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
@@ -20,135 +20,19 @@ import type { ChangeEvent } from "react";
 import { useMemo, useState } from "react";
 
 const STORAGE_KEY = "worksheet_coach_v1";
-const ENC_VERSION = "v1";
-const SALT_BYTES = 16;
-const IV_BYTES = 12;
-const MIN_PASSPHRASE_LENGTH = 8;
 
-const isWebCryptoAvailable = () =>
-  typeof window !== "undefined" && Boolean(window.crypto?.subtle);
-
-const toBase64 = (value: Uint8Array): string => {
-  if (typeof window !== "undefined" && typeof window.btoa === "function") {
-    let binary = "";
-    value.forEach((byte) => {
-      binary += String.fromCharCode(byte);
-    });
-    return window.btoa(binary);
-  }
-  if (typeof Buffer !== "undefined") {
-    return Buffer.from(value).toString("base64");
-  }
-  throw new Error("Base64 encoding is not supported in this environment.");
-};
-
-const fromBase64 = (encoded: string): Uint8Array => {
-  if (typeof window !== "undefined" && typeof window.atob === "function") {
-    const binary = window.atob(encoded);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i += 1) {
-      bytes[i] = binary.charCodeAt(i);
-    }
-    return bytes;
-  }
-  if (typeof Buffer !== "undefined") {
-    return new Uint8Array(Buffer.from(encoded, "base64"));
-  }
-  throw new Error("Base64 decoding is not supported in this environment.");
-};
-
-async function deriveKey(passphrase: string, salt: Uint8Array) {
-  if (!isWebCryptoAvailable()) {
-    throw new Error("Web Crypto API is not available.");
-  }
-
-  const encoder = new TextEncoder();
-  const material = await window.crypto.subtle.importKey(
-    "raw",
-    encoder.encode(passphrase),
-    "PBKDF2",
-    false,
-    ["deriveKey"]
-  );
-
-  return window.crypto.subtle.deriveKey(
-    {
-      name: "PBKDF2",
-      salt: salt.buffer as ArrayBuffer,
-      iterations: 250_000,
-      hash: "SHA-256",
-    },
-    material,
-    {
-      name: "AES-GCM",
-      length: 256,
-    },
-    false,
-    ["encrypt", "decrypt"]
-  );
-}
-
-async function encryptFormData(
-  passphrase: string,
-  form: CoachForm
-): Promise<string> {
-  if (!isWebCryptoAvailable()) {
-    throw new Error("Web Crypto API is not available.");
-  }
-
-  const salt = window.crypto.getRandomValues(new Uint8Array(SALT_BYTES));
-  const iv = window.crypto.getRandomValues(new Uint8Array(IV_BYTES));
-  const key = await deriveKey(passphrase, salt);
-  const encoder = new TextEncoder();
-  const payload = encoder.encode(JSON.stringify(form));
-  const encrypted = await window.crypto.subtle.encrypt(
-    { name: "AES-GCM", iv: iv.buffer as ArrayBuffer },
-    key,
-    payload
-  );
-
-  return [
-    ENC_VERSION,
-    toBase64(salt),
-    toBase64(iv),
-    toBase64(new Uint8Array(encrypted)),
-  ].join(":");
-}
-
-async function decryptFormData(
-  passphrase: string,
-  record: string
-): Promise<CoachForm | null> {
-  if (!isWebCryptoAvailable()) {
-    return null;
+function readInitialForm(): CoachForm {
+  if (typeof window === "undefined") {
+    return {};
   }
 
   try {
-    const [version, saltEncoded, ivEncoded, payloadEncoded] = record.split(":");
-    if (
-      version !== ENC_VERSION ||
-      !saltEncoded ||
-      !ivEncoded ||
-      !payloadEncoded
-    ) {
-      return null;
-    }
-
-    const salt = fromBase64(saltEncoded);
-    const iv = fromBase64(ivEncoded);
-    const payload = fromBase64(payloadEncoded);
-    const key = await deriveKey(passphrase, salt);
-    const decrypted = await window.crypto.subtle.decrypt(
-      { name: "AES-GCM", iv: iv.buffer as ArrayBuffer },
-      key,
-      payload.buffer as ArrayBuffer
-    );
-    const decoder = new TextDecoder();
-    const json = decoder.decode(decrypted);
-    return JSON.parse(json) as CoachForm;
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    return JSON.parse(raw) as CoachForm;
   } catch (error) {
-    console.warn("Failed to decrypt coach worksheet", error);
-    return null;
+    console.warn("Failed to parse coach worksheet state", error);
+    return {};
   }
 }
 
@@ -170,23 +54,11 @@ type ChangeHandler = (
 
 export function CoachWorksheet() {
   useDocumentTitle("Coach Worksheet");
-  const [form, setForm] = useState<CoachForm>({});
-  const [passphrase, setPassphrase] = useState<string>("");
-  const [storedCipher, setStoredCipher] = useState<string | null>(() =>
-    typeof window === "undefined"
-      ? null
-      : window.localStorage.getItem(STORAGE_KEY)
-  );
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const [form, setForm] = useState<CoachForm>(() => readInitialForm());
   const [saveStatus, setSaveStatus] = useState<{
     type: "success" | "error";
     message: string;
   } | null>(null);
-  const [saving, setSaving] = useState(false);
-  const [unlocking, setUnlocking] = useState(false);
-
-  const cryptoSupported = isWebCryptoAvailable();
-  const hasSavedData = Boolean(storedCipher);
 
   const handleChange: ChangeHandler = (key) => (event) => {
     const target = event.target as HTMLInputElement;
@@ -207,84 +79,14 @@ export function CoachWorksheet() {
     setSaveStatus(null);
   };
 
-  const handlePassphraseChange = (
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    setPassphrase(event.target.value);
-    setLoadError(null);
-    setSaveStatus(null);
-  };
-
-  const handleUnlock = async () => {
-    if (!cryptoSupported) {
-      setLoadError("This browser does not support secure storage.");
-      return;
-    }
-
-    if (!hasSavedData) {
-      setLoadError("No encrypted notes were found on this device.");
-      return;
-    }
-
-    const secret = passphrase.trim();
-
-    if (secret.length < MIN_PASSPHRASE_LENGTH) {
-      setLoadError(
-        `Passphrase must be at least ${MIN_PASSPHRASE_LENGTH} characters to unlock saved notes.`
-      );
-      return;
-    }
-
-    setUnlocking(true);
-    setLoadError(null);
-    try {
-      const decrypted = await decryptFormData(secret, storedCipher!);
-      if (!decrypted) {
-        setLoadError(
-          "Unable to unlock saved notes with the provided passphrase."
-        );
-        return;
-      }
-      setForm(decrypted);
-      setLoadError(null);
-      setSaveStatus(null);
-    } catch {
-      setLoadError("Unable to unlock saved notes right now.");
-    } finally {
-      setUnlocking(false);
-    }
-  };
-
-  const handleSave = async () => {
+  const handleSave = () => {
     if (typeof window === "undefined") return;
-    if (!cryptoSupported) {
-      setSaveStatus({
-        type: "error",
-        message:
-          "This browser does not support the required security features.",
-      });
-      return;
-    }
 
-    const secret = passphrase.trim();
-
-    if (secret.length < MIN_PASSPHRASE_LENGTH) {
-      setSaveStatus({
-        type: "error",
-        message: `Passphrase must be at least ${MIN_PASSPHRASE_LENGTH} characters to save notes.`,
-      });
-      return;
-    }
-
-    setSaving(true);
-    setSaveStatus(null);
     try {
-      const encrypted = await encryptFormData(secret, form);
-      window.localStorage.setItem(STORAGE_KEY, encrypted);
-      setStoredCipher(encrypted);
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(form));
       setSaveStatus({
         type: "success",
-        message: "Saved encrypted notes to this device.",
+        message: "Saved notes to this device.",
       });
     } catch (error) {
       console.warn("Failed to persist coach worksheet", error);
@@ -292,8 +94,6 @@ export function CoachWorksheet() {
         type: "error",
         message: "Failed to save notes. Please try again.",
       });
-    } finally {
-      setSaving(false);
     }
   };
 
@@ -302,9 +102,6 @@ export function CoachWorksheet() {
     if (!window.confirm("Clear all saved inputs for Coach worksheet?")) return;
     window.localStorage.removeItem(STORAGE_KEY);
     setForm({});
-    setStoredCipher(null);
-    setPassphrase("");
-    setLoadError(null);
     setSaveStatus({
       type: "success",
       message: "Saved notes have been removed from this device.",
@@ -777,29 +574,13 @@ export function CoachWorksheet() {
           <Stack spacing={2.5}>
             <Stack spacing={0.5}>
               <Typography variant="h6" sx={{ fontWeight: 700 }}>
-                Protect your notes
+                Save your notes
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Set a personal passphrase to encrypt anything you save on this
-                device. The same passphrase is required to unlock the notes
-                later.
+                Save your progress to this device so you can revisit and edit
+                it later. Saved notes stay only on this browser.
               </Typography>
             </Stack>
-
-            <TextField
-              label="Encryption passphrase"
-              type="password"
-              value={passphrase}
-              onChange={handlePassphraseChange}
-              fullWidth
-              autoComplete="new-password"
-              disabled={!cryptoSupported}
-              helperText={
-                cryptoSupported
-                  ? `Use at least ${MIN_PASSPHRASE_LENGTH} characters.`
-                  : "Secure local storage requires a browser with Web Crypto support."
-              }
-            />
 
             <Stack
               direction={{ xs: "column", sm: "row" }}
@@ -807,42 +588,15 @@ export function CoachWorksheet() {
               justifyContent="flex-end"
             >
               <Button
-                variant="outlined"
-                onClick={() => {
-                  void handleUnlock();
-                }}
-                disabled={
-                  !cryptoSupported ||
-                  !hasSavedData ||
-                  passphrase.trim().length < MIN_PASSPHRASE_LENGTH ||
-                  unlocking
-                }
-              >
-                {unlocking ? "Unlocking…" : "Unlock saved data"}
-              </Button>
-              <Button
                 variant="contained"
-                onClick={() => {
-                  void handleSave();
-                }}
-                disabled={
-                  !cryptoSupported ||
-                  passphrase.trim().length < MIN_PASSPHRASE_LENGTH ||
-                  saving
-                }
+                onClick={handleSave}
               >
-                {saving ? "Saving…" : "Save securely"}
+                Save
               </Button>
               <Button variant="outlined" color="warning" onClick={handleClear}>
                 Clear
               </Button>
             </Stack>
-
-            {loadError ? (
-              <Typography color="error.main" variant="body2">
-                {loadError}
-              </Typography>
-            ) : null}
 
             {saveStatus ? (
               <Typography
@@ -852,13 +606,6 @@ export function CoachWorksheet() {
                 variant="body2"
               >
                 {saveStatus.message}
-              </Typography>
-            ) : null}
-
-            {!cryptoSupported ? (
-              <Typography color="warning.main" variant="body2">
-                Your browser does not support the Web Crypto API. Saved notes
-                will remain unavailable until you switch to a supported browser.
               </Typography>
             ) : null}
           </Stack>


### PR DESCRIPTION
## Summary
- load coach worksheet state from localStorage without requiring a passphrase
- simplify the save/clear actions and messaging to match the other worksheets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbdf275db8832595c64691c6ee32e9