### PR TITLE
Persist worksheets in Turso

### DIFF
--- a/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
@@ -2,6 +2,7 @@
 
 import { useDocumentTitle } from "@/hooks/use-document-title";
 import {
+  Alert,
   Avatar,
   Box,
   Button,
@@ -17,9 +18,7 @@ import {
   Typography,
 } from "@mui/material";
 import type { ChangeEvent } from "react";
-import { useMemo, useState } from "react";
-
-const STORAGE_KEY = "worksheet_coach_v1";
+import { useEffect, useMemo, useState } from "react";
 const ENC_VERSION = "v1";
 const SALT_BYTES = 16;
 const IV_BYTES = 12;
@@ -172,11 +171,7 @@ export function CoachWorksheet() {
   useDocumentTitle("Coach Worksheet");
   const [form, setForm] = useState<CoachForm>({});
   const [passphrase, setPassphrase] = useState<string>("");
-  const [storedCipher, setStoredCipher] = useState<string | null>(() =>
-    typeof window === "undefined"
-      ? null
-      : window.localStorage.getItem(STORAGE_KEY)
-  );
+  const [storedCipher, setStoredCipher] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saveStatus, setSaveStatus] = useState<{
     type: "success" | "error";
@@ -184,9 +179,64 @@ export function CoachWorksheet() {
   } | null>(null);
   const [saving, setSaving] = useState(false);
   const [unlocking, setUnlocking] = useState(false);
+  const [initialError, setInitialError] = useState<string | null>(null);
 
   const cryptoSupported = isWebCryptoAvailable();
   const hasSavedData = Boolean(storedCipher);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setInitialError(null);
+      try {
+        const response = await fetch("/api/worksheets/coach", {
+          method: "GET",
+          credentials: "include",
+        });
+        const payload = (await response.json().catch(() => null)) as
+          | { ok: true; worksheet: { data: unknown } | null }
+          | { ok: false; error?: { message?: string } }
+          | null;
+
+        if (!response.ok || payload?.ok === false) {
+          const message =
+            payload?.error?.message ??
+            "Unable to load saved worksheet data. Please try again.";
+          throw new Error(message);
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        const data = payload?.worksheet?.data;
+        if (typeof data === "string") {
+          setStoredCipher(data);
+        } else if (data && typeof data === "object") {
+          setForm(data as CoachForm);
+          setStoredCipher(null);
+        } else {
+          setStoredCipher(null);
+        }
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Unable to load saved worksheet data.";
+        setInitialError(message);
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleChange: ChangeHandler = (key) => (event) => {
     const target = event.target as HTMLInputElement;
@@ -222,7 +272,7 @@ export function CoachWorksheet() {
     }
 
     if (!hasSavedData) {
-      setLoadError("No encrypted notes were found on this device.");
+      setLoadError("No encrypted notes were found for this account.");
       return;
     }
 
@@ -256,7 +306,6 @@ export function CoachWorksheet() {
   };
 
   const handleSave = async () => {
-    if (typeof window === "undefined") return;
     if (!cryptoSupported) {
       setSaveStatus({
         type: "error",
@@ -280,35 +329,88 @@ export function CoachWorksheet() {
     setSaveStatus(null);
     try {
       const encrypted = await encryptFormData(secret, form);
-      window.localStorage.setItem(STORAGE_KEY, encrypted);
+      const response = await fetch("/api/worksheets/coach", {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ data: encrypted }),
+      });
+      const payload = (await response.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error?: { message?: string } }
+        | null;
+
+      if (!response.ok || payload?.ok === false) {
+        const message =
+          payload?.error?.message ??
+          "Unable to save notes right now. Please try again.";
+        throw new Error(message);
+      }
+
       setStoredCipher(encrypted);
       setSaveStatus({
         type: "success",
-        message: "Saved encrypted notes to this device.",
+        message: "Saved encrypted notes.",
       });
     } catch (error) {
       console.warn("Failed to persist coach worksheet", error);
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to save notes. Please try again.";
       setSaveStatus({
         type: "error",
-        message: "Failed to save notes. Please try again.",
+        message,
       });
     } finally {
       setSaving(false);
     }
   };
 
-  const handleClear = () => {
-    if (typeof window === "undefined") return;
-    if (!window.confirm("Clear all saved inputs for Coach worksheet?")) return;
-    window.localStorage.removeItem(STORAGE_KEY);
-    setForm({});
-    setStoredCipher(null);
-    setPassphrase("");
-    setLoadError(null);
-    setSaveStatus({
-      type: "success",
-      message: "Saved notes have been removed from this device.",
-    });
+  const handleClear = async () => {
+    if (typeof window !== "undefined") {
+      const confirmed = window.confirm(
+        "Clear all saved inputs for Coach worksheet?"
+      );
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    setSaveStatus(null);
+    try {
+      const response = await fetch("/api/worksheets/coach", {
+        method: "DELETE",
+        credentials: "include",
+      });
+      const payload = (await response.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error?: { message?: string } }
+        | null;
+
+      if (!response.ok || payload?.ok === false) {
+        const message =
+          payload?.error?.message ??
+          "Unable to clear notes right now. Please try again.";
+        throw new Error(message);
+      }
+
+      setForm({});
+      setStoredCipher(null);
+      setPassphrase("");
+      setLoadError(null);
+      setInitialError(null);
+      setSaveStatus({
+        type: "success",
+        message: "Saved notes have been removed.",
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to clear notes right now.";
+      setSaveStatus({ type: "error", message });
+    }
   };
 
   const issueTypeChecks = useMemo(
@@ -369,6 +471,11 @@ export function CoachWorksheet() {
   return (
     <Container maxWidth="md" sx={{ my: 4, pb: 8 }}>
       <Stack spacing={3}>
+        {initialError && (
+          <Alert severity="error" variant="outlined">
+            {initialError}
+          </Alert>
+        )}
         <Paper
           sx={{
             p: { xs: 3, md: 4 },
@@ -780,8 +887,8 @@ export function CoachWorksheet() {
                 Protect your notes
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Set a personal passphrase to encrypt anything you save on this
-                device. The same passphrase is required to unlock the notes
+                Set a personal passphrase to encrypt anything you save for this
+                account. The same passphrase is required to unlock the notes
                 later.
               </Typography>
             </Stack>
@@ -833,7 +940,13 @@ export function CoachWorksheet() {
               >
                 {saving ? "Saving…" : "Save securely"}
               </Button>
-              <Button variant="outlined" color="warning" onClick={handleClear}>
+              <Button
+                variant="outlined"
+                color="warning"
+                onClick={() => {
+                  void handleClear();
+                }}
+              >
                 Clear
               </Button>
             </Stack>

--- a/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/coach-worksheet.tsx
@@ -201,7 +201,9 @@ export function CoachWorksheet() {
 
         if (!response.ok || payload?.ok === false) {
           const message =
-            payload?.error?.message ??
+            (payload && "error" in payload
+              ? payload.error?.message
+              : undefined) ??
             "Unable to load saved worksheet data. Please try again.";
           throw new Error(message);
         }
@@ -340,10 +342,12 @@ export function CoachWorksheet() {
         | { ok: false; error?: { message?: string } }
         | null;
 
-      if (!response.ok || payload?.ok === false) {
-        const message =
-          payload?.error?.message ??
-          "Unable to save notes right now. Please try again.";
+        if (!response.ok || payload?.ok === false) {
+          const message =
+            (payload && "error" in payload
+              ? payload.error?.message
+              : undefined) ??
+            "Unable to save notes right now. Please try again.";
         throw new Error(message);
       }
 
@@ -388,10 +392,12 @@ export function CoachWorksheet() {
         | { ok: false; error?: { message?: string } }
         | null;
 
-      if (!response.ok || payload?.ok === false) {
-        const message =
-          payload?.error?.message ??
-          "Unable to clear notes right now. Please try again.";
+        if (!response.ok || payload?.ok === false) {
+          const message =
+            (payload && "error" in payload
+              ? payload.error?.message
+              : undefined) ??
+            "Unable to clear notes right now. Please try again.";
         throw new Error(message);
       }
 

--- a/src/app/(protected)/worksheets/_components/observer-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/observer-worksheet.tsx
@@ -2,6 +2,7 @@
 
 import { useDocumentTitle } from "@/hooks/use-document-title";
 import {
+  Alert,
   Avatar,
   Box,
   Button,
@@ -14,9 +15,7 @@ import {
   Typography,
 } from "@mui/material";
 import type { ChangeEvent } from "react";
-import { useMemo, useState } from "react";
-
-const STORAGE_KEY = "worksheet_observer_v1";
+import { useEffect, useMemo, useState } from "react";
 
 type ObserverForm = {
   good?: string;
@@ -31,46 +30,157 @@ type ChangeHandler = (
   key: keyof ObserverForm
 ) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 
-function readInitialForm(): ObserverForm {
-  if (typeof window === "undefined") {
+function normalizeFormValue(value: unknown): ObserverForm {
+  if (!value || typeof value !== "object") {
     return {};
   }
-
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as ObserverForm) : {};
-  } catch (error) {
-    console.warn("Failed to parse observer worksheet state", error);
-    return {};
-  }
+  return value as ObserverForm;
 }
 
 export function ObserverWorksheet() {
   useDocumentTitle("Observer Worksheet");
-  const [form, setForm] = useState<ObserverForm>(() => readInitialForm());
+  const [form, setForm] = useState<ObserverForm>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [status, setStatus] = useState<
+    { type: "success" | "error"; message: string }
+  | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const response = await fetch("/api/worksheets/observer", {
+          method: "GET",
+          credentials: "include",
+        });
+        const payload = (await response.json().catch(() => null)) as
+          | { ok: true; worksheet: { data: unknown } | null }
+          | { ok: false; error?: { message?: string } }
+          | null;
+
+        if (!response.ok || payload?.ok === false) {
+          const message =
+            payload?.error?.message ??
+            "Unable to load saved worksheet data. Please try again.";
+          throw new Error(message);
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        setForm(normalizeFormValue(payload?.worksheet?.data ?? {}));
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Unable to load saved worksheet data.";
+        setLoadError(message);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleChange: ChangeHandler = (key) => (event) => {
+    setStatus(null);
     setForm((prev) => ({
       ...prev,
       [key]: event.target.value,
     }));
   };
 
-  const handleSave = () => {
-    if (typeof window === "undefined") return;
+  const handleSave = async () => {
+    setSaving(true);
+    setStatus(null);
     try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(form));
+      const response = await fetch("/api/worksheets/observer", {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ data: form }),
+      });
+      const payload = (await response.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error?: { message?: string } }
+        | null;
+
+      if (!response.ok || payload?.ok === false) {
+        const message =
+          payload?.error?.message ??
+          "Unable to save worksheet right now. Please try again.";
+        throw new Error(message);
+      }
+
+      setStatus({ type: "success", message: "Worksheet saved." });
     } catch (error) {
-      console.warn("Failed to persist observer worksheet", error);
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to save worksheet right now.";
+      setStatus({ type: "error", message });
+    } finally {
+      setSaving(false);
     }
   };
 
-  const handleClear = () => {
-    if (typeof window === "undefined") return;
-    if (!window.confirm("Clear all saved inputs for Observer worksheet?"))
-      return;
-    window.localStorage.removeItem(STORAGE_KEY);
-    setForm({});
+  const handleClear = async () => {
+    if (typeof window !== "undefined") {
+      const confirmed = window.confirm(
+        "Clear all saved inputs for Observer worksheet?"
+      );
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    setClearing(true);
+    setStatus(null);
+    try {
+      const response = await fetch("/api/worksheets/observer", {
+        method: "DELETE",
+        credentials: "include",
+      });
+      const payload = (await response.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error?: { message?: string } }
+        | null;
+
+      if (!response.ok || payload?.ok === false) {
+        const message =
+          payload?.error?.message ??
+          "Unable to clear worksheet right now. Please try again.";
+        throw new Error(message);
+      }
+
+      setForm({});
+      setStatus({ type: "success", message: "Worksheet cleared." });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to clear worksheet right now.";
+      setStatus({ type: "error", message });
+    } finally {
+      setClearing(false);
+    }
   };
 
   const protocolSections = useMemo(
@@ -139,6 +249,11 @@ export function ObserverWorksheet() {
   return (
     <Container maxWidth="md" sx={{ my: 4, pb: 8 }}>
       <Stack spacing={3}>
+        {loadError && (
+          <Alert severity="error" variant="outlined">
+            {loadError}
+          </Alert>
+        )}
         <Paper
           sx={{
             p: { xs: 3, md: 4 },
@@ -376,17 +491,33 @@ export function ObserverWorksheet() {
             bgcolor: "background.paper",
           }}
         >
-          <Stack
-            direction={{ xs: "column", sm: "row" }}
-            spacing={1}
-            justifyContent="flex-end"
-          >
-            <Button variant="contained" onClick={handleSave}>
-              Save locally
-            </Button>
-            <Button variant="outlined" color="warning" onClick={handleClear}>
-              Clear
-            </Button>
+          <Stack spacing={1.5}>
+            {status && (
+              <Alert severity={status.type} variant="outlined">
+                {status.message}
+              </Alert>
+            )}
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={1}
+              justifyContent="flex-end"
+            >
+              <Button
+                variant="contained"
+                onClick={handleSave}
+                disabled={loading || saving || clearing}
+              >
+                Save
+              </Button>
+              <Button
+                variant="outlined"
+                color="warning"
+                onClick={handleClear}
+                disabled={clearing || saving}
+              >
+                Clear
+              </Button>
+            </Stack>
           </Stack>
         </Paper>
       </Stack>

--- a/src/app/(protected)/worksheets/_components/observer-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/observer-worksheet.tsx
@@ -66,7 +66,9 @@ export function ObserverWorksheet() {
 
         if (!response.ok || payload?.ok === false) {
           const message =
-            payload?.error?.message ??
+            (payload && "error" in payload
+              ? payload.error?.message
+              : undefined) ??
             "Unable to load saved worksheet data. Please try again.";
           throw new Error(message);
         }
@@ -122,10 +124,12 @@ export function ObserverWorksheet() {
         | { ok: false; error?: { message?: string } }
         | null;
 
-      if (!response.ok || payload?.ok === false) {
-        const message =
-          payload?.error?.message ??
-          "Unable to save worksheet right now. Please try again.";
+        if (!response.ok || payload?.ok === false) {
+          const message =
+            (payload && "error" in payload
+              ? payload.error?.message
+              : undefined) ??
+            "Unable to save worksheet right now. Please try again.";
         throw new Error(message);
       }
 
@@ -163,10 +167,12 @@ export function ObserverWorksheet() {
         | { ok: false; error?: { message?: string } }
         | null;
 
-      if (!response.ok || payload?.ok === false) {
-        const message =
-          payload?.error?.message ??
-          "Unable to clear worksheet right now. Please try again.";
+        if (!response.ok || payload?.ok === false) {
+          const message =
+            (payload && "error" in payload
+              ? payload.error?.message
+              : undefined) ??
+            "Unable to clear worksheet right now. Please try again.";
         throw new Error(message);
       }
 

--- a/src/app/(protected)/worksheets/_components/presenter-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/presenter-worksheet.tsx
@@ -93,7 +93,9 @@ export function PresenterWorksheet() {
 
         if (!response.ok || payload?.ok === false) {
           const message =
-            payload?.error?.message ??
+            (payload && "error" in payload
+              ? payload.error?.message
+              : undefined) ??
             "Unable to load saved worksheet data. Please try again.";
           throw new Error(message);
         }
@@ -153,10 +155,12 @@ export function PresenterWorksheet() {
         | { ok: false; error?: { message?: string } }
         | null;
 
-      if (!response.ok || payload?.ok === false) {
-        const message =
-          payload?.error?.message ??
-          "Unable to save worksheet right now. Please try again.";
+        if (!response.ok || payload?.ok === false) {
+          const message =
+            (payload && "error" in payload
+              ? payload.error?.message
+              : undefined) ??
+            "Unable to save worksheet right now. Please try again.";
         throw new Error(message);
       }
 
@@ -194,10 +198,12 @@ export function PresenterWorksheet() {
         | { ok: false; error?: { message?: string } }
         | null;
 
-      if (!response.ok || payload?.ok === false) {
-        const message =
-          payload?.error?.message ??
-          "Unable to clear worksheet right now. Please try again.";
+        if (!response.ok || payload?.ok === false) {
+          const message =
+            (payload && "error" in payload
+              ? payload.error?.message
+              : undefined) ??
+            "Unable to clear worksheet right now. Please try again.";
         throw new Error(message);
       }
 

--- a/src/app/(protected)/worksheets/_components/presenter-worksheet.tsx
+++ b/src/app/(protected)/worksheets/_components/presenter-worksheet.tsx
@@ -2,6 +2,7 @@
 
 import { useDocumentTitle } from "@/hooks/use-document-title";
 import {
+  Alert,
   Avatar,
   Box,
   Button,
@@ -17,9 +18,7 @@ import {
   Typography,
 } from "@mui/material";
 import type { ChangeEvent } from "react";
-import { useMemo, useState } from "react";
-
-const STORAGE_KEY = "worksheet_presenter_v1";
+import { useEffect, useMemo, useState } from "react";
 
 type PresenterForm = {
   context?: string;
@@ -34,31 +33,23 @@ type PresenterForm = {
   ask?: string;
 };
 
-function readInitialForm(): PresenterForm {
-  if (typeof window === "undefined") {
+function normalizeFormValue(value: unknown): PresenterForm {
+  if (!value || typeof value !== "object") {
     return {};
   }
 
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as PresenterForm;
-
-    const legacyType = (parsed.type ?? "").toLowerCase();
-    return {
-      ...parsed,
-      typeWork: parsed.typeWork ?? legacyType.includes("work"),
-      typeHome:
-        parsed.typeHome ??
-        (legacyType.includes("home") || legacyType.includes("family")),
-      typePersonal:
-        parsed.typePersonal ??
-        (legacyType.includes("personal") || legacyType.includes("self")),
-    };
-  } catch (error) {
-    console.warn("Failed to parse presenter worksheet state", error);
-    return {};
-  }
+  const parsed = value as PresenterForm;
+  const legacyType = (parsed.type ?? "").toLowerCase();
+  return {
+    ...parsed,
+    typeWork: parsed.typeWork ?? legacyType.includes("work"),
+    typeHome:
+      parsed.typeHome ??
+      (legacyType.includes("home") || legacyType.includes("family")),
+    typePersonal:
+      parsed.typePersonal ??
+      (legacyType.includes("personal") || legacyType.includes("self")),
+  };
 }
 
 type ChangeHandler = (
@@ -67,33 +58,163 @@ type ChangeHandler = (
 
 export function PresenterWorksheet() {
   useDocumentTitle("Presenter Worksheet");
-  const [form, setForm] = useState<PresenterForm>(() => readInitialForm());
+  const [form, setForm] = useState<PresenterForm>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [status, setStatus] = useState<
+    { type: "success" | "error"; message: string }
+  | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const response = await fetch("/api/worksheets/presenter", {
+          method: "GET",
+          credentials: "include",
+        });
+        const payload = (await response.json().catch(() => null)) as
+          | {
+              ok: true;
+              worksheet: { data: unknown } | null;
+              error?: undefined;
+            }
+          | {
+              ok: false;
+              error?: { message?: string };
+              worksheet?: undefined;
+            }
+          | null;
+
+        if (!response.ok || payload?.ok === false) {
+          const message =
+            payload?.error?.message ??
+            "Unable to load saved worksheet data. Please try again.";
+          throw new Error(message);
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        const data = payload?.worksheet?.data;
+        setForm(normalizeFormValue(data));
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Unable to load saved worksheet data.";
+        setLoadError(message);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleChange: ChangeHandler = (key) => (event) => {
     const target = event.target as HTMLInputElement;
     const value =
       target.type === "checkbox" ? target.checked : event.target.value;
+    setStatus(null);
     setForm((prev) => ({
       ...prev,
       [key]: value,
     }));
   };
 
-  const handleSave = () => {
-    if (typeof window === "undefined") return;
+  const handleSave = async () => {
+    setSaving(true);
+    setStatus(null);
     try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(form));
+      const response = await fetch("/api/worksheets/presenter", {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ data: form }),
+      });
+      const payload = (await response.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error?: { message?: string } }
+        | null;
+
+      if (!response.ok || payload?.ok === false) {
+        const message =
+          payload?.error?.message ??
+          "Unable to save worksheet right now. Please try again.";
+        throw new Error(message);
+      }
+
+      setStatus({ type: "success", message: "Worksheet saved." });
     } catch (error) {
-      console.warn("Failed to persist presenter worksheet", error);
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to save worksheet right now.";
+      setStatus({ type: "error", message });
+    } finally {
+      setSaving(false);
     }
   };
 
-  const handleClear = () => {
-    if (typeof window === "undefined") return;
-    if (!window.confirm("Clear all saved inputs for Presenter worksheet?"))
-      return;
-    window.localStorage.removeItem(STORAGE_KEY);
-    setForm({});
+  const handleClear = async () => {
+    if (typeof window !== "undefined") {
+      const confirmed = window.confirm(
+        "Clear all saved inputs for Presenter worksheet?"
+      );
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    setClearing(true);
+    setStatus(null);
+    try {
+      const response = await fetch("/api/worksheets/presenter", {
+        method: "DELETE",
+        credentials: "include",
+      });
+      const payload = (await response.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error?: { message?: string } }
+        | null;
+
+      if (!response.ok || payload?.ok === false) {
+        const message =
+          payload?.error?.message ??
+          "Unable to clear worksheet right now. Please try again.";
+        throw new Error(message);
+      }
+
+      setForm({});
+      setStatus({
+        type: "success",
+        message: "Worksheet cleared.",
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to clear worksheet right now.";
+      setStatus({ type: "error", message });
+    } finally {
+      setClearing(false);
+    }
   };
 
   const issueTypeChecks = useMemo(
@@ -129,6 +250,11 @@ export function PresenterWorksheet() {
   return (
     <Container maxWidth="md" sx={{ my: 4, pb: 8 }}>
       <Stack spacing={3}>
+        {loadError && (
+          <Alert severity="error" variant="outlined">
+            {loadError}
+          </Alert>
+        )}
         <Paper
           sx={{
             p: { xs: 3, md: 4 },
@@ -431,17 +557,33 @@ export function PresenterWorksheet() {
             bgcolor: "background.paper",
           }}
         >
-          <Stack
-            direction={{ xs: "column", sm: "row" }}
-            spacing={1}
-            justifyContent="flex-end"
-          >
-            <Button variant="contained" onClick={handleSave}>
-              Save locally
-            </Button>
-            <Button variant="outlined" color="warning" onClick={handleClear}>
-              Clear
-            </Button>
+          <Stack spacing={1.5}>
+            {status && (
+              <Alert severity={status.type} variant="outlined">
+                {status.message}
+              </Alert>
+            )}
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={1}
+              justifyContent="flex-end"
+            >
+              <Button
+                variant="contained"
+                onClick={handleSave}
+                disabled={loading || saving || clearing}
+              >
+                Save
+              </Button>
+              <Button
+                variant="outlined"
+                color="warning"
+                onClick={handleClear}
+                disabled={clearing || saving}
+              >
+                Clear
+              </Button>
+            </Stack>
           </Stack>
         </Paper>
       </Stack>

--- a/src/app/api/worksheets/[role]/route.ts
+++ b/src/app/api/worksheets/[role]/route.ts
@@ -41,16 +41,21 @@ async function resolveRole(context: RouteContext): Promise<WorksheetRole | null>
   }
 }
 
-type AuthResolution = {
-  email: string | null;
-  response: NextResponse | null;
-};
+type AuthResolution =
+  | {
+      status: "authenticated";
+      email: string;
+    }
+  | {
+      status: "unauthenticated";
+      response: NextResponse;
+    };
 
 async function resolveAuthenticatedEmail(): Promise<AuthResolution> {
   const session = await getOptionalUserSession();
   if (!session) {
     return {
-      email: null,
+      status: "unauthenticated",
       response: NextResponse.json(
         {
           ok: false,
@@ -64,7 +69,7 @@ async function resolveAuthenticatedEmail(): Promise<AuthResolution> {
   const email = session.user?.email?.trim();
   if (!email) {
     return {
-      email: null,
+      status: "unauthenticated",
       response: NextResponse.json(
         {
           ok: false,
@@ -78,7 +83,7 @@ async function resolveAuthenticatedEmail(): Promise<AuthResolution> {
     };
   }
 
-  return { email, response: null };
+  return { status: "authenticated", email };
 }
 
 export async function GET(_request: NextRequest, context: RouteContext) {
@@ -93,13 +98,13 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     );
   }
 
-  const { email, response } = await resolveAuthenticatedEmail();
-  if (email === null) {
-    return response;
+  const auth = await resolveAuthenticatedEmail();
+  if (auth.status === "unauthenticated") {
+    return auth.response;
   }
 
   try {
-    const record = await getWorksheet(email, role);
+    const record = await getWorksheet(auth.email, role);
     return NextResponse.json({
       ok: true,
       worksheet: record
@@ -136,9 +141,9 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     );
   }
 
-  const { email, response } = await resolveAuthenticatedEmail();
-  if (email === null) {
-    return response;
+  const auth = await resolveAuthenticatedEmail();
+  if (auth.status === "unauthenticated") {
+    return auth.response;
   }
 
   let payload: SaveWorksheetPayload;
@@ -155,7 +160,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
   }
 
   try {
-    await upsertWorksheet(email, role, payload.data ?? null);
+    await upsertWorksheet(auth.email, role, payload.data ?? null);
     return NextResponse.json({ ok: true });
   } catch (error) {
     console.error("Failed to save worksheet", error);
@@ -187,13 +192,13 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     );
   }
 
-  const { email, response } = await resolveAuthenticatedEmail();
-  if (email === null) {
-    return response;
+  const auth = await resolveAuthenticatedEmail();
+  if (auth.status === "unauthenticated") {
+    return auth.response;
   }
 
   try {
-    await deleteWorksheet(email, role);
+    await deleteWorksheet(auth.email, role);
     return NextResponse.json({ ok: true });
   } catch (error) {
     console.error("Failed to clear worksheet", error);

--- a/src/app/api/worksheets/[role]/route.ts
+++ b/src/app/api/worksheets/[role]/route.ts
@@ -89,7 +89,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   }
 
   const { email, response } = await resolveAuthenticatedEmail();
-  if (!email) {
+  if (email === null) {
     return response;
   }
 
@@ -132,7 +132,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
   }
 
   const { email, response } = await resolveAuthenticatedEmail();
-  if (!email) {
+  if (email === null) {
     return response;
   }
 
@@ -183,7 +183,7 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
   }
 
   const { email, response } = await resolveAuthenticatedEmail();
-  if (!email) {
+  if (email === null) {
     return response;
   }
 

--- a/src/app/api/worksheets/[role]/route.ts
+++ b/src/app/api/worksheets/[role]/route.ts
@@ -41,11 +41,16 @@ async function resolveRole(context: RouteContext): Promise<WorksheetRole | null>
   }
 }
 
-async function resolveAuthenticatedEmail() {
+type AuthResolution = {
+  email: string | null;
+  response: NextResponse | null;
+};
+
+async function resolveAuthenticatedEmail(): Promise<AuthResolution> {
   const session = await getOptionalUserSession();
   if (!session) {
     return {
-      email: null as const,
+      email: null,
       response: NextResponse.json(
         {
           ok: false,
@@ -53,13 +58,13 @@ async function resolveAuthenticatedEmail() {
         },
         { status: 401 }
       ),
-    } as const;
+    };
   }
 
   const email = session.user?.email?.trim();
   if (!email) {
     return {
-      email: null as const,
+      email: null,
       response: NextResponse.json(
         {
           ok: false,
@@ -70,10 +75,10 @@ async function resolveAuthenticatedEmail() {
         },
         { status: 400 }
       ),
-    } as const;
+    };
   }
 
-  return { email, response: null as const };
+  return { email, response: null };
 }
 
 export async function GET(_request: NextRequest, context: RouteContext) {

--- a/src/app/api/worksheets/[role]/route.ts
+++ b/src/app/api/worksheets/[role]/route.ts
@@ -8,12 +8,15 @@ import {
   type WorksheetRole,
 } from "@/lib/worksheets";
 import { JsonBodyError, requireJson } from "@/lib/utils";
+import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
+type Awaitable<T> = T | Promise<T>;
+
 type RouteContext = {
-  params: {
-    role?: string;
-  };
+  params: Awaitable<{
+    role: string;
+  }>;
 };
 
 type SaveWorksheetPayload = {
@@ -26,6 +29,16 @@ function normalizeRole(value: string | undefined): WorksheetRole | null {
   }
   const normalized = value.toLowerCase();
   return isValidWorksheetRole(normalized) ? normalized : null;
+}
+
+async function resolveRole(context: RouteContext): Promise<WorksheetRole | null> {
+  try {
+    const params = await context.params;
+    return normalizeRole(params?.role);
+  } catch (error) {
+    console.error("Failed to resolve worksheet role", error);
+    return null;
+  }
 }
 
 async function resolveAuthenticatedEmail() {
@@ -63,8 +76,8 @@ async function resolveAuthenticatedEmail() {
   return { email, response: null as const };
 }
 
-export async function GET(_request: Request, context: RouteContext) {
-  const role = normalizeRole(context.params?.role);
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const role = await resolveRole(context);
   if (!role) {
     return NextResponse.json(
       {
@@ -106,8 +119,8 @@ export async function GET(_request: Request, context: RouteContext) {
   }
 }
 
-export async function PUT(request: Request, context: RouteContext) {
-  const role = normalizeRole(context.params?.role);
+export async function PUT(request: NextRequest, context: RouteContext) {
+  const role = await resolveRole(context);
   if (!role) {
     return NextResponse.json(
       {
@@ -157,8 +170,8 @@ export async function PUT(request: Request, context: RouteContext) {
   }
 }
 
-export async function DELETE(_request: Request, context: RouteContext) {
-  const role = normalizeRole(context.params?.role);
+export async function DELETE(_request: NextRequest, context: RouteContext) {
+  const role = await resolveRole(context);
   if (!role) {
     return NextResponse.json(
       {

--- a/src/app/api/worksheets/[role]/route.ts
+++ b/src/app/api/worksheets/[role]/route.ts
@@ -1,0 +1,197 @@
+import { getOptionalUserSession } from "@/lib/session";
+import { TursoUnavailableError } from "@/lib/turso";
+import {
+  deleteWorksheet,
+  getWorksheet,
+  isValidWorksheetRole,
+  upsertWorksheet,
+  type WorksheetRole,
+} from "@/lib/worksheets";
+import { JsonBodyError, requireJson } from "@/lib/utils";
+import { NextResponse } from "next/server";
+
+type RouteContext = {
+  params: {
+    role?: string;
+  };
+};
+
+type SaveWorksheetPayload = {
+  data?: unknown;
+};
+
+function normalizeRole(value: string | undefined): WorksheetRole | null {
+  if (!value) {
+    return null;
+  }
+  const normalized = value.toLowerCase();
+  return isValidWorksheetRole(normalized) ? normalized : null;
+}
+
+async function resolveAuthenticatedEmail() {
+  const session = await getOptionalUserSession();
+  if (!session) {
+    return {
+      email: null as const,
+      response: NextResponse.json(
+        {
+          ok: false,
+          error: { code: "UNAUTHENTICATED", message: "Authentication required." },
+        },
+        { status: 401 }
+      ),
+    } as const;
+  }
+
+  const email = session.user?.email?.trim();
+  if (!email) {
+    return {
+      email: null as const,
+      response: NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: "NO_EMAIL",
+            message: "Unable to determine user email for this session.",
+          },
+        },
+        { status: 400 }
+      ),
+    } as const;
+  }
+
+  return { email, response: null as const };
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  const role = normalizeRole(context.params?.role);
+  if (!role) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "INVALID_ROLE", message: "Unknown worksheet role." },
+      },
+      { status: 400 }
+    );
+  }
+
+  const { email, response } = await resolveAuthenticatedEmail();
+  if (!email) {
+    return response;
+  }
+
+  try {
+    const record = await getWorksheet(email, role);
+    return NextResponse.json({
+      ok: true,
+      worksheet: record
+        ? { data: record.data, updatedAt: record.updatedAt, role: record.role }
+        : null,
+    });
+  } catch (error) {
+    console.error("Failed to load worksheet", error);
+    const unavailable = error instanceof TursoUnavailableError;
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: unavailable ? "DATABASE_UNAVAILABLE" : "FETCH_FAILED",
+          message: unavailable
+            ? "Worksheets cannot be loaded because the database is currently unavailable."
+            : "Unable to load worksheet data right now. Please try again soon.",
+        },
+      },
+      { status: 503 }
+    );
+  }
+}
+
+export async function PUT(request: Request, context: RouteContext) {
+  const role = normalizeRole(context.params?.role);
+  if (!role) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "INVALID_ROLE", message: "Unknown worksheet role." },
+      },
+      { status: 400 }
+    );
+  }
+
+  const { email, response } = await resolveAuthenticatedEmail();
+  if (!email) {
+    return response;
+  }
+
+  let payload: SaveWorksheetPayload;
+  try {
+    payload = await requireJson<SaveWorksheetPayload>(request);
+  } catch (error) {
+    if (error instanceof JsonBodyError) {
+      return NextResponse.json(
+        { ok: false, error: { code: "INVALID_JSON", message: error.message } },
+        { status: error.status }
+      );
+    }
+    throw error;
+  }
+
+  try {
+    await upsertWorksheet(email, role, payload.data ?? null);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Failed to save worksheet", error);
+    const unavailable = error instanceof TursoUnavailableError;
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: unavailable ? "DATABASE_UNAVAILABLE" : "SAVE_FAILED",
+          message: unavailable
+            ? "Worksheets cannot be saved because the database is currently unavailable."
+            : "Unable to save worksheet right now. Please try again later.",
+        },
+      },
+      { status: 503 }
+    );
+  }
+}
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  const role = normalizeRole(context.params?.role);
+  if (!role) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "INVALID_ROLE", message: "Unknown worksheet role." },
+      },
+      { status: 400 }
+    );
+  }
+
+  const { email, response } = await resolveAuthenticatedEmail();
+  if (!email) {
+    return response;
+  }
+
+  try {
+    await deleteWorksheet(email, role);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Failed to clear worksheet", error);
+    const unavailable = error instanceof TursoUnavailableError;
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: unavailable ? "DATABASE_UNAVAILABLE" : "DELETE_FAILED",
+          message: unavailable
+            ? "Worksheets cannot be cleared because the database is currently unavailable."
+            : "Unable to clear worksheet right now. Please try again later.",
+        },
+      },
+      { status: 503 }
+    );
+  }
+}
+

--- a/src/lib/worksheets.ts
+++ b/src/lib/worksheets.ts
@@ -1,0 +1,274 @@
+import { TursoUnavailableError, execute, isTursoConfigured } from "@/lib/turso";
+
+export const WORKSHEET_ROLES = [
+  "presenter",
+  "coach",
+  "observer",
+] as const;
+
+export type WorksheetRole = (typeof WORKSHEET_ROLES)[number];
+
+export type WorksheetRecord<T = unknown> = {
+  uid: string;
+  role: WorksheetRole;
+  data: T | null;
+  updatedAt: string | null;
+};
+
+type WorksheetsTableSchema = {
+  idColumn?: string;
+  uidColumn: string;
+  roleColumn: string;
+  dataColumn: string;
+  updatedAtColumn?: string;
+  createdAtColumn?: string;
+};
+
+let cachedSchema: WorksheetsTableSchema | null = null;
+
+function assertTursoAvailable(): void {
+  if (!isTursoConfigured()) {
+    throw new TursoUnavailableError();
+  }
+}
+
+function extractColumnName(row: unknown): string | null {
+  if (!row) {
+    return null;
+  }
+
+  if (Array.isArray(row)) {
+    const value = row[1];
+    if (typeof value === "string") {
+      return value;
+    }
+    if (value != null) {
+      return String(value);
+    }
+    return null;
+  }
+
+  if (typeof row === "object") {
+    const record = row as Record<string, unknown>;
+    const value = record.name;
+    if (typeof value === "string") {
+      return value;
+    }
+    if (value != null) {
+      return String(value);
+    }
+  }
+
+  return null;
+}
+
+function pickColumn(
+  columnMap: Map<string, string>,
+  candidates: string[],
+  { required = false }: { required?: boolean } = {}
+): string | undefined {
+  for (const candidate of candidates) {
+    const column = columnMap.get(candidate.toLowerCase());
+    if (column) {
+      return column;
+    }
+  }
+
+  if (required) {
+    const available = Array.from(columnMap.values()).join(", ");
+    throw new Error(
+      `[worksheets] Required column not found. Tried ${candidates.join(", ")} in table with columns: ${available}`
+    );
+  }
+
+  return undefined;
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+async function getSchema(): Promise<WorksheetsTableSchema> {
+  if (cachedSchema) {
+    return cachedSchema;
+  }
+
+  assertTursoAvailable();
+  const result = await execute("PRAGMA table_info('worksheets')");
+  const rows = (result?.rows ?? []) as Array<Record<string, unknown> | unknown[]>;
+  const columnMap = new Map<string, string>();
+
+  for (const row of rows) {
+    const name = extractColumnName(row);
+    if (name) {
+      columnMap.set(name.toLowerCase(), name);
+    }
+  }
+
+  if (columnMap.size === 0) {
+    throw new Error("[worksheets] worksheets table is missing or has no columns");
+  }
+
+  const schema: WorksheetsTableSchema = {
+    idColumn: pickColumn(columnMap, ["id", "worksheet_id", "rowid"]),
+    uidColumn: pickColumn(columnMap, ["uid", "user_id", "user_uid", "email"], {
+      required: true,
+    })!,
+    roleColumn: pickColumn(columnMap, ["role", "worksheet_role", "type"], {
+      required: true,
+    })!,
+    dataColumn: pickColumn(columnMap, ["data", "payload", "content", "form"], {
+      required: true,
+    })!,
+    updatedAtColumn: pickColumn(columnMap, [
+      "updated_at",
+      "updatedon",
+      "updated",
+      "modified_at",
+      "modified",
+      "updatedat",
+    ]),
+    createdAtColumn: pickColumn(columnMap, [
+      "created_at",
+      "createdon",
+      "created",
+      "createdat",
+    ]),
+  };
+
+  cachedSchema = schema;
+  return schema;
+}
+
+function parseStoredData(raw: unknown): unknown {
+  if (raw == null) {
+    return null;
+  }
+
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return raw;
+    }
+  }
+
+  return raw;
+}
+
+export async function getWorksheet<T = unknown>(
+  uid: string,
+  role: WorksheetRole
+): Promise<WorksheetRecord<T> | null> {
+  assertTursoAvailable();
+  const schema = await getSchema();
+  const { uidColumn, roleColumn, dataColumn, updatedAtColumn } = schema;
+
+  const selectColumns = [
+    `${quoteIdentifier(uidColumn)} AS uid`,
+    `${quoteIdentifier(roleColumn)} AS role`,
+    `${quoteIdentifier(dataColumn)} AS data`,
+  ];
+
+  if (updatedAtColumn) {
+    selectColumns.push(`${quoteIdentifier(updatedAtColumn)} AS updated_at`);
+  }
+
+  const result = await execute(
+    `SELECT ${selectColumns.join(", ")}
+       FROM worksheets
+      WHERE ${quoteIdentifier(uidColumn)} = ?1
+        AND ${quoteIdentifier(roleColumn)} = ?2
+      LIMIT 1`,
+    [uid, role]
+  );
+
+  const row = (result.rows?.[0] ?? null) as Record<string, unknown> | null;
+  if (!row) {
+    return null;
+  }
+
+  const data = parseStoredData(row.data) as T | null;
+  const updatedAtValue = row.updated_at;
+  const updatedAt =
+    typeof updatedAtValue === "string"
+      ? updatedAtValue
+      : updatedAtValue != null
+      ? String(updatedAtValue)
+      : null;
+
+  return {
+    uid,
+    role: row.role as WorksheetRole,
+    data,
+    updatedAt,
+  };
+}
+
+export async function upsertWorksheet<T = unknown>(
+  uid: string,
+  role: WorksheetRole,
+  data: T
+): Promise<void> {
+  assertTursoAvailable();
+  const schema = await getSchema();
+  const { uidColumn, roleColumn, dataColumn, updatedAtColumn, createdAtColumn } =
+    schema;
+
+  const columns = [uidColumn, roleColumn, dataColumn];
+  const placeholders = ["?1", "?2", "?3"];
+
+  const values: unknown[] = [uid, role, JSON.stringify(data ?? null)];
+
+  if (createdAtColumn) {
+    columns.push(createdAtColumn);
+    placeholders.push("datetime('now')");
+  }
+
+  if (updatedAtColumn) {
+    columns.push(updatedAtColumn);
+    placeholders.push("datetime('now')");
+  }
+
+  const insertColumns = columns.map(quoteIdentifier).join(", ");
+  const insertValues = placeholders.join(", ");
+  const conflictTarget = `${quoteIdentifier(uidColumn)}, ${quoteIdentifier(roleColumn)}`;
+  const updateAssignments = [
+    `${quoteIdentifier(dataColumn)} = excluded.${quoteIdentifier(dataColumn)}`,
+  ];
+
+  if (updatedAtColumn) {
+    updateAssignments.push(
+      `${quoteIdentifier(updatedAtColumn)} = datetime('now')`
+    );
+  }
+
+  await execute(
+    `INSERT INTO worksheets (${insertColumns})
+       VALUES (${insertValues})
+       ON CONFLICT(${conflictTarget}) DO UPDATE SET ${updateAssignments.join(", ")}`,
+    values
+  );
+}
+
+export async function deleteWorksheet(
+  uid: string,
+  role: WorksheetRole
+): Promise<void> {
+  assertTursoAvailable();
+  const schema = await getSchema();
+  const { uidColumn, roleColumn } = schema;
+
+  await execute(
+    `DELETE FROM worksheets WHERE ${quoteIdentifier(uidColumn)} = ?1 AND ${quoteIdentifier(roleColumn)} = ?2`,
+    [uid, role]
+  );
+}
+
+export function isValidWorksheetRole(value: string): value is WorksheetRole {
+  return (WORKSHEET_ROLES as readonly string[]).includes(value);
+}
+
+export function resetWorksheetsCache(): void {
+  cachedSchema = null;
+}


### PR DESCRIPTION
## Summary
- add a worksheets persistence helper for Turso and expose a role-based API route
- switch the presenter and observer worksheets to load, save, and clear data through the new API with inline status messaging
- update the coach worksheet to fetch and store encrypted notes in Turso instead of local storage

## Testing
- npm run lint *(warnings about unused variables in public/sw.js)*

------
https://chatgpt.com/codex/tasks/task_e_68dc59f1d3848325829ac198ab3dea37