### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hidenobunagai/goen-net/security/code-scanning/8](https://github.com/hidenobunagai/goen-net/security/code-scanning/8)

To resolve this security issue, you should explicitly set the `permissions` block at the workflow root, which will apply "least privilege" to all jobs unless overridden. For these jobs (linting, typechecking, building), set `contents: read` as the only required permission. This should be added just after the `name` field and before the `on:` field in `.github/workflows/ci.yml`. No additional methods, imports, or variable definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
