### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hidenobunagai/goen-net/security/code-scanning/9](https://github.com/hidenobunagai/goen-net/security/code-scanning/9)

To fix the problem, add an explicit `permissions` block to the workflow YAML. This can be placed at the workflow root (above the `jobs:` block), which ensures all jobs inherit these permissions unless individually overridden. For jobs that only require checkout and read access to repository contents, set `contents: read`, which is the minimal sensible default. If a job actually needs more permissions (such as uploading artifacts, or creating issues/pull requests), you can add those granular permissions as needed at the job level.  
For the code provided, add a `permissions:` block to the root of the file, just below the `name:` declaration and before the `on:` trigger.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
