### PR TITLE
Use structured logger in session and updates flows

### DIFF
--- a/src/app/(protected)/prioritization/_components/prioritization-board.tsx
+++ b/src/app/(protected)/prioritization/_components/prioritization-board.tsx
@@ -45,6 +45,7 @@ import {
 import type { SelectChangeEvent } from "@mui/material/Select";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { logger } from "@/lib/logger";
 import type { UpdateRecord } from "@/lib/updates";
 
 const STORAGE_KEY = "goen-prioritization-board-v1";
@@ -255,7 +256,12 @@ export function PrioritizationBoard() {
         setBoard(createBoardWithUpdates(storedBoard, items));
       } catch (err) {
         if (controller.signal.aborted) return;
-        console.error("Failed to load prioritization data", err);
+        logger.error("Failed to load prioritization data", {
+          url: "/api/updates",
+          limit: 200,
+          error:
+            err instanceof Error ? { name: err.name, message: err.message, stack: err.stack } : err,
+        });
         setError(err instanceof Error ? err.message : "Failed to load updates.");
         setUpdates([]);
         setBoard(createBoardWithUpdates(null, []));

--- a/src/app/(protected)/updates/page.tsx
+++ b/src/app/(protected)/updates/page.tsx
@@ -1,4 +1,5 @@
 import { UpdatesBoard } from "@/app/(protected)/updates/_components";
+import { logger } from "@/lib/logger";
 import { requireUserSession } from "@/lib/session";
 import type { UpdateRecord } from "@/lib/updates";
 import { fetchUpdates } from "@/lib/updates";
@@ -12,7 +13,15 @@ export default async function UpdatesPage() {
     try {
       updates = await fetchUpdates(viewerEmail, { limit: 200 });
     } catch (error) {
-      console.error("Failed to load updates during initial render", error);
+      const context = {
+        viewerEmail,
+        limit: 200,
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message, stack: error.stack }
+            : error,
+      };
+      logger.error("Failed to load updates during initial render", context);
       updates = [];
     }
   }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -34,6 +34,7 @@ class Logger {
 
     switch (level) {
       case "error":
+        // eslint-disable-next-line no-console
         console.error(JSON.stringify(logEntry));
         break;
       case "warn":

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -3,6 +3,7 @@ import type { Session } from "next-auth";
 import { getServerSession } from "next-auth";
 
 import { authOptions } from "@/lib/auth";
+import { logger } from "@/lib/logger";
 
 async function resolveServerSession(): Promise<Session | null> {
   try {
@@ -14,7 +15,14 @@ async function resolveServerSession(): Promise<Session | null> {
         : undefined;
 
     if (digest !== "DYNAMIC_SERVER_USAGE" && digest !== "NEXT_REDIRECT") {
-      console.error("Failed to resolve server session", error);
+      const context = {
+        digest,
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message, stack: error.stack }
+            : error,
+      };
+      logger.error("Failed to resolve server session", context);
     }
     return null;
   }


### PR DESCRIPTION
## Summary
- switch updates page and session helper to use the shared logger with structured error metadata
- replace the prioritization board console error with the shared logger and context details
- annotate the logger implementation so eslint accepts console.error in production logging

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fa0b8df883259851611947106232)