### PR TITLE
Add schema validation for update payload

### DIFF
--- a/src/app/api/updates/route.ts
+++ b/src/app/api/updates/route.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
 import { NextResponse } from "next/server";
+import { z } from "zod";
 
 import { logger } from "@/lib/logger";
 import { checkRateLimit } from "@/lib/rate-limit";
@@ -74,15 +75,25 @@ export async function GET(request: Request) {
   }
 }
 
-type CreateUpdatePayload = {
-  by?: string;
-  category?: number;
-  urgent?: boolean;
-  priority?: boolean;
-  title?: string | null;
-  update?: string;
-  when?: number;
-};
+const createUpdateSchema = z.object({
+  by: z.string().optional(),
+  category: z
+    .number({ invalid_type_error: "category must be a number." })
+    .refine((value): value is 0 | 1 | 2 => value === 0 || value === 1 || value === 2, {
+      message: "category must be one of 0, 1, or 2.",
+    })
+    .optional(),
+  urgent: z.boolean().optional(),
+  priority: z.boolean().optional(),
+  title: z.string().nullable().optional(),
+  update: z.string().optional(),
+  when: z
+    .number({ invalid_type_error: "when must be a number." })
+    .refine((value): value is -1 | 1 => value === -1 || value === 1, {
+      message: "when must be either -1 or 1.",
+    })
+    .optional(),
+});
 
 export async function POST(request: Request) {
   const session = await getOptionalUserSession();
@@ -96,9 +107,9 @@ export async function POST(request: Request) {
     );
   }
 
-  let body: CreateUpdatePayload;
+  let payload: unknown;
   try {
-    body = await requireJson<CreateUpdatePayload>(request);
+    payload = await requireJson(request);
   } catch (error: unknown) {
     if (error instanceof JsonBodyError) {
       return NextResponse.json(
@@ -108,12 +119,34 @@ export async function POST(request: Request) {
     }
     throw error;
   }
+  const parsed = createUpdateSchema.safeParse(payload);
+  if (!parsed.success) {
+    const issueMessages = parsed.error.issues.map((issue) => {
+      if (issue.path[0] === "category") {
+        return "category must be one of 0, 1, or 2.";
+      }
+      if (issue.path[0] === "when") {
+        return "when must be either -1 or 1.";
+      }
+      const path = issue.path.join(".") || "body";
+      return `${path}: ${issue.message}`;
+    });
+    const message = `Invalid request body. ${issueMessages.join(" ")}`.trim();
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "INVALID_BODY", message },
+      },
+      { status: 422 }
+    );
+  }
+  const body = parsed.data;
   const by = typeof body?.by === "string" ? body.by.trim() : (session.user?.name ?? "Unknown");
-  const category = Number(body?.category ?? 0);
+  const category = body.category ?? 0;
   const urgent = Boolean(typeof body?.urgent === "boolean" ? body.urgent : body?.priority);
   const title = typeof body?.title === "string" ? body.title.trim() : "";
   const updateText = typeof body?.update === "string" ? body.update.trim() : "";
-  const when = Number(body?.when ?? -1);
+  const when = body.when ?? -1;
 
   if (!title) {
     return NextResponse.json(

--- a/src/app/api/updates/route.ts
+++ b/src/app/api/updates/route.ts
@@ -78,7 +78,7 @@ export async function GET(request: Request) {
 const createUpdateSchema = z.object({
   by: z.string().optional(),
   category: z
-    .number({ invalid_type_error: "category must be a number." })
+    .number()
     .refine((value): value is 0 | 1 | 2 => value === 0 || value === 1 || value === 2, {
       message: "category must be one of 0, 1, or 2.",
     })
@@ -88,7 +88,7 @@ const createUpdateSchema = z.object({
   title: z.string().nullable().optional(),
   update: z.string().optional(),
   when: z
-    .number({ invalid_type_error: "when must be a number." })
+    .number()
     .refine((value): value is -1 | 1 => value === -1 || value === 1, {
       message: "when must be either -1 or 1.",
     })
@@ -123,10 +123,14 @@ export async function POST(request: Request) {
   if (!parsed.success) {
     const issueMessages = parsed.error.issues.map((issue) => {
       if (issue.path[0] === "category") {
-        return "category must be one of 0, 1, or 2.";
+        return issue.code === "invalid_type"
+          ? "category must be a number."
+          : "category must be one of 0, 1, or 2.";
       }
       if (issue.path[0] === "when") {
-        return "when must be either -1 or 1.";
+        return issue.code === "invalid_type"
+          ? "when must be a number."
+          : "when must be either -1 or 1.";
       }
       const path = issue.path.join(".") || "body";
       return `${path}: ${issue.message}`;

--- a/tests/api/updates.test.ts
+++ b/tests/api/updates.test.ts
@@ -129,6 +129,50 @@ describe("/api/updates route", () => {
     expect(body.error.code).toBe("INVALID_BODY");
   });
 
+  it("rejects POST with invalid category", async () => {
+    vi.mocked(getServerSession).mockResolvedValueOnce({
+      user: { email: "user@example.com", name: "User" },
+    } as never);
+    vi.mocked(requireJson).mockResolvedValueOnce({
+      title: "Update title",
+      update: "text",
+      when: 1,
+      category: 5,
+    });
+
+    const request = new Request("http://localhost/api/updates", {
+      method: "POST",
+    });
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error.code).toBe("INVALID_BODY");
+    expect(body.error.message).toContain("category must be one of 0, 1, or 2.");
+  });
+
+  it("rejects POST with invalid when", async () => {
+    vi.mocked(getServerSession).mockResolvedValueOnce({
+      user: { email: "user@example.com", name: "User" },
+    } as never);
+    vi.mocked(requireJson).mockResolvedValueOnce({
+      title: "Update title",
+      update: "text",
+      when: 0,
+      category: 1,
+    });
+
+    const request = new Request("http://localhost/api/updates", {
+      method: "POST",
+    });
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error.code).toBe("INVALID_BODY");
+    expect(body.error.message).toContain("when must be either -1 or 1.");
+  });
+
   it("enforces POST rate limit", async () => {
     vi.mocked(getServerSession).mockResolvedValueOnce({
       user: { email: "user@example.com", name: "User" },

--- a/tests/api/updates.test.ts
+++ b/tests/api/updates.test.ts
@@ -151,6 +151,28 @@ describe("/api/updates route", () => {
     expect(body.error.message).toContain("category must be one of 0, 1, or 2.");
   });
 
+  it("rejects POST when category is not a number", async () => {
+    vi.mocked(getServerSession).mockResolvedValueOnce({
+      user: { email: "user@example.com", name: "User" },
+    } as never);
+    vi.mocked(requireJson).mockResolvedValueOnce({
+      title: "Update title",
+      update: "text",
+      when: -1,
+      category: "urgent",
+    });
+
+    const request = new Request("http://localhost/api/updates", {
+      method: "POST",
+    });
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error.code).toBe("INVALID_BODY");
+    expect(body.error.message).toContain("category must be a number.");
+  });
+
   it("rejects POST with invalid when", async () => {
     vi.mocked(getServerSession).mockResolvedValueOnce({
       user: { email: "user@example.com", name: "User" },
@@ -171,6 +193,28 @@ describe("/api/updates route", () => {
     expect(response.status).toBe(422);
     expect(body.error.code).toBe("INVALID_BODY");
     expect(body.error.message).toContain("when must be either -1 or 1.");
+  });
+
+  it("rejects POST when when is not a number", async () => {
+    vi.mocked(getServerSession).mockResolvedValueOnce({
+      user: { email: "user@example.com", name: "User" },
+    } as never);
+    vi.mocked(requireJson).mockResolvedValueOnce({
+      title: "Update title",
+      update: "text",
+      when: "now",
+      category: 1,
+    });
+
+    const request = new Request("http://localhost/api/updates", {
+      method: "POST",
+    });
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error.code).toBe("INVALID_BODY");
+    expect(body.error.message).toContain("when must be a number.");
   });
 
   it("enforces POST rate limit", async () => {


### PR DESCRIPTION
## Summary
- validate the updates POST payload with a Zod schema and return 422 errors with details when validation fails
- restrict the category and when fields to their supported values before inserting updates
- cover the new validation error paths with unit tests

## Testing
- npm run test:updates

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fc35c1c483259f5a7cc00689944f)