### PR TITLE
fix: add /api/updates route and fix client-side refetch, stats, and m…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20.12.0"
-          cache: "pnpm"
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run ESLint
-        run: pnpm run lint
+        run: bun run lint
 
   typecheck:
     name: TypeScript Type Check
@@ -45,22 +37,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20.12.0"
-          cache: "pnpm"
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run TypeScript compiler
-        run: pnpm exec tsc --noEmit
+        run: bunx tsc --noEmit
 
   build:
     name: Build
@@ -71,26 +55,15 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20.12.0"
-          cache: "pnpm"
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Build application
-        run: pnpm run build
+        run: bun run build
         env:
-          # 必須環境変数（ダミー値）
-          # 注: secrets の警告は Settings > Secrets に値を設定することで解消されます
-          # 未設定の場合はフォールバック値が使用されます
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'test-secret-at-least-32-characters-long' }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID || 'test-client-id' }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET || 'test-client-secret' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,24 +19,15 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20.12.0"
-          cache: "pnpm"
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run Vitest tests
-        run: pnpm run test:updates
+        run: bun run test:updates
         env:
-          # テスト用環境変数
           NEXTAUTH_SECRET: test-secret-at-least-32-characters-long-for-testing
           GOOGLE_CLIENT_ID: test-google-client-id
           GOOGLE_CLIENT_SECRET: test-google-client-secret
@@ -44,7 +35,6 @@ jobs:
   e2e-tests:
     name: E2E Tests (Playwright)
     runs-on: ubuntu-latest
-    # E2Eテストはオプショナル（環境変数がある場合のみ実行）
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout code
@@ -52,32 +42,21 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20.12.0"
-          cache: "pnpm"
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps
+        run: bunx playwright install --with-deps
 
       - name: Run Playwright tests
-        run: pnpm run test:playwright
+        run: bun run test:playwright
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:3000
           PLAYWRIGHT_TEST_EMAIL: ${{ secrets.PLAYWRIGHT_TEST_EMAIL }}
           PLAYWRIGHT_TEST_PASSWORD: ${{ secrets.PLAYWRIGHT_TEST_PASSWORD }}
-          # アプリケーション環境変数
-          # アプリケーション環境変数
-          # 注: secrets の警告は Settings > Secrets に値を設定することで解消されます
           NEXTAUTH_SECRET: test-secret-at-least-32-characters-long-for-testing
           NEXTAUTH_URL: http://localhost:3000
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID || 'test-google-client-id' }}

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Goen Net is a supportive mentoring network for visionary leaders who are committ
 
 1. **Install dependencies**
 
-   ```powershell
-   npm install
+   ```bash
+   bun install
    ```
 
 2. **Create your environment file**
@@ -50,8 +50,8 @@ Goen Net is a supportive mentoring network for visionary leaders who are committ
 
 3. **Run the application**
 
-   ```powershell
-   npm run dev
+   ```bash
+   bun run dev
    ```
 
    Unauthenticated users are redirected to `/signin` and sent back once Google sign-in succeeds.
@@ -105,9 +105,9 @@ If validation fails, the app will not start and will display detailed error mess
 
 ## 🧪 Testing and Linting
 
-- `npm run lint` – Run ESLint across the project.
-- `npm run test:updates` – Execute Vitest API suites.
-- `npm run test:playwright` – Launch Playwright end-to-end tests (requires `PLAYWRIGHT_TEST_EMAIL` and `PLAYWRIGHT_TEST_PASSWORD`).
+- `bun run lint` – Run ESLint across the project.
+- `bun run test:updates` – Execute Vitest API suites.
+- `bun run test:playwright` – Launch Playwright end-to-end tests (requires `PLAYWRIGHT_TEST_EMAIL` and `PLAYWRIGHT_TEST_PASSWORD`).
 
 ## ☁️ Deployment
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,7 @@ const eslintConfig = [
       "next-env.d.ts",
       "legacy/**",
       "src/components/emails/**",
+      "patch.js",
     ],
   },
   {

--- a/src/app/(protected)/_components/next-session-card.tsx
+++ b/src/app/(protected)/_components/next-session-card.tsx
@@ -16,6 +16,7 @@ import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Unstable_Grid2";
+import { useRouter } from "next/navigation";
 import { useMemo, useState, useTransition } from "react";
 
 import {
@@ -67,6 +68,7 @@ export function NextSessionCard({ initial }: { initial: InitialSession | null })
   }, [locationValue]);
   const locationLabel = locationValue || "To be determined";
 
+  const router = useRouter();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
   const [status, setStatus] = useState<StatusState>(null);
@@ -164,7 +166,7 @@ export function NextSessionCard({ initial }: { initial: InitialSession | null })
           message: "Next session updated successfully.",
         });
         setDialogOpen(false);
-        window.location.reload();
+        router.refresh();
       } catch (error) {
         const message = error instanceof Error ? error.message : "Failed to update next session.";
         setStatus({ type: "error", message });

--- a/src/app/(protected)/documentation/_components/moderator-guide.tsx
+++ b/src/app/(protected)/documentation/_components/moderator-guide.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import KeyboardArrowLeft from "@mui/icons-material/KeyboardArrowLeft";
+import KeyboardArrowRight from "@mui/icons-material/KeyboardArrowRight";
 import {
   Box,
   Button,
@@ -13,8 +15,6 @@ import {
   ToggleButtonGroup,
   Typography,
 } from "@mui/material";
-import KeyboardArrowLeft from "@mui/icons-material/KeyboardArrowLeft";
-import KeyboardArrowRight from "@mui/icons-material/KeyboardArrowRight";
 import type { PropsWithChildren } from "react";
 import { useEffect, useState } from "react";
 

--- a/src/app/(protected)/prioritization/_components/prioritization-board.tsx
+++ b/src/app/(protected)/prioritization/_components/prioritization-board.tsx
@@ -237,7 +237,6 @@ export function PrioritizationBoard({ initialUpdates }: PrioritizationBoardProps
   useEffect(() => {
     const storedBoard = loadBoardFromStorage();
     setBoard(createBoardWithUpdates(storedBoard, updates));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Run once on mount to initialize board with updates
 
   useEffect(() => {

--- a/src/app/(protected)/updates/_components/updates-list.tsx
+++ b/src/app/(protected)/updates/_components/updates-list.tsx
@@ -28,7 +28,6 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState, useTransition } from "react";
 
 import type { UpdateRecord } from "@/lib/updates";
-import { fetchUpdates } from "@/lib/updates";
 
 import { deleteAllUpdatesAction, deleteUpdateAction } from "../actions";
 import { DeleteAllUpdatesDialog, DeleteUpdateDialog } from "./delete-dialogs";
@@ -58,7 +57,6 @@ export function UpdatesBoard({ viewerEmail }: UpdatesBoardProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
-  // Use React Query to fetch updates data
   const {
     data: updates = [],
     isLoading,
@@ -66,10 +64,17 @@ export function UpdatesBoard({ viewerEmail }: UpdatesBoardProps) {
     refetch,
   } = useQuery({
     queryKey: ["updates", viewerEmail],
-    queryFn: () => fetchUpdates(viewerEmail!, { limit: 200 }),
+    queryFn: async (): Promise<UpdateRecord[]> => {
+      const response = await fetch("/api/updates?limit=200");
+      if (!response.ok) {
+        throw new Error("Failed to fetch updates");
+      }
+      const json = await response.json();
+      return json.updates as UpdateRecord[];
+    },
     enabled: !!viewerEmail,
-    staleTime: 60 * 1000, // 1 minute
-    refetchInterval: 30 * 1000, // Refetch every 30 seconds for real-time updates
+    staleTime: 60 * 1000,
+    refetchInterval: 30 * 1000,
   });
 
   const [selectedUid, setSelectedUid] = useState<string>("all");

--- a/src/app/(protected)/updates/_components/updates-summary.tsx
+++ b/src/app/(protected)/updates/_components/updates-summary.tsx
@@ -1,1 +1,0 @@
-// (deprecated) Historical UpdatesSummary component has been removed.

--- a/src/app/(protected)/updates/page.tsx
+++ b/src/app/(protected)/updates/page.tsx
@@ -1,8 +1,8 @@
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 import { UpdatesBoard } from "@/app/(protected)/updates/_components";
-import { getQueryClient } from "@/lib/query-client";
 import { logger } from "@/lib/logger";
+import { getQueryClient } from "@/lib/query-client";
 import { requireUserSession } from "@/lib/session";
 import { fetchUpdates } from "@/lib/updates";
 

--- a/src/app/api/meetings/upcoming/route.ts
+++ b/src/app/api/meetings/upcoming/route.ts
@@ -1,48 +1,52 @@
 import { NextResponse } from "next/server";
 
 import { logger } from "@/lib/logger";
-import { Meeting } from "@/types/meetings";
-
-// Mock data for demonstration
-const mockMeetings: Meeting[] = [
-  {
-    id: "1",
-    title: "October Goen Net Forum",
-    date: new Date("2025-10-05T10:00:00").toISOString(),
-    duration: 180, // 3 hours in minutes
-    status: "scheduled",
-    attendees: ["alice@example.com", "bob@example.com", "charlie@example.com", "diana@example.com"],
-    description: "Monthly alumni forum discussing recent updates and strategic initiatives",
-    location: "Conference Room A",
-    agenda: [
-      "Welcome & Check-ins (15min)",
-      "Updates Review & Prioritization (60min)",
-      "Strategic Discussion (75min)",
-      "Action Items & Next Steps (30min)",
-    ],
-  },
-  {
-    id: "2",
-    title: "Q4 Planning Session",
-    date: new Date("2025-11-15T14:00:00").toISOString(),
-    duration: 120,
-    status: "scheduled",
-    attendees: ["alice@example.com", "bob@example.com", "eve@example.com"],
-    description: "Quarterly planning and goal setting",
-    location: "Online",
-  },
-];
+import { getOptionalUserSession } from "@/lib/session";
+import { getNextSession, isTursoConfigured } from "@/lib/turso";
+import type { Meeting } from "@/types/meetings";
 
 export async function GET() {
   try {
-    // Return upcoming meeting (next chronologically)
-    const upcomingMeetings = mockMeetings
-      .filter((meeting) => new Date(meeting.date) > new Date())
-      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    const session = await getOptionalUserSession();
+    if (!session?.user?.email) {
+      return NextResponse.json(
+        { error: { code: "UNAUTHENTICATED", message: "Authentication required." } },
+        { status: 401 }
+      );
+    }
 
-    const nextMeeting = upcomingMeetings[0] || null;
+    if (!isTursoConfigured()) {
+      return NextResponse.json(null);
+    }
 
-    return NextResponse.json(nextMeeting);
+    const nextSession = await getNextSession();
+
+    if (!nextSession?.startAt) {
+      return NextResponse.json(null);
+    }
+
+    const sessionDate = new Date(nextSession.startAt);
+    if (Number.isNaN(sessionDate.getTime()) || sessionDate <= new Date()) {
+      return NextResponse.json(null);
+    }
+
+    const durationMs =
+      nextSession.endAt && !Number.isNaN(new Date(nextSession.endAt).getTime())
+        ? new Date(nextSession.endAt).getTime() - sessionDate.getTime()
+        : 3 * 60 * 60 * 1000;
+    const durationMinutes = Math.round(durationMs / (1000 * 60));
+
+    const meeting: Meeting = {
+      id: "next-session",
+      title: "Goen Net Session",
+      date: sessionDate.toISOString(),
+      duration: durationMinutes,
+      status: "scheduled",
+      attendees: [],
+      location: nextSession.location ?? undefined,
+    };
+
+    return NextResponse.json(meeting);
   } catch (error) {
     logger.error("Error fetching upcoming meeting", { error });
     return NextResponse.json({ error: "Failed to fetch upcoming meeting" }, { status: 500 });

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import { logger } from "@/lib/logger";
 import { getOptionalUserSession } from "@/lib/session";
+import { getNextSession, isTursoConfigured } from "@/lib/turso";
 import { fetchUpdates } from "@/lib/updates";
 
 export interface StatsData {
@@ -13,46 +14,38 @@ export interface StatsData {
 
 export async function GET() {
   try {
-    logger.info("Stats endpoint called", { endpoint: "/api/stats" });
     const session = await getOptionalUserSession();
 
     if (!session?.user?.email) {
-      logger.info("No session found, returning mock data");
-      // Return mock data for unauthenticated users (shouldn't happen in protected routes)
-      const stats: StatsData = {
-        totalUpdates: 12,
-        urgentItems: 3,
-        activeMembers: 8,
-        daysToMeeting: 5,
-      };
-
-      const response = NextResponse.json(stats);
-      response.headers.set("Cache-Control", "no-cache, no-store, must-revalidate");
-      response.headers.set("Pragma", "no-cache");
-      response.headers.set("Expires", "0");
-      return response;
+      return NextResponse.json(
+        { error: { code: "UNAUTHENTICATED", message: "Authentication required." } },
+        { status: 401 }
+      );
     }
 
-    logger.info("Session found, fetching real data", { email: session.user.email });
-    // Fetch real data from database
-    const updates = await fetchUpdates(session.user.email, {
-      limit: 100,
-      offset: 0,
-    });
+    const [updates, nextSession] = await Promise.all([
+      fetchUpdates(session.user.email, { limit: 100, offset: 0 }),
+      isTursoConfigured() ? getNextSession().catch(() => null) : Promise.resolve(null),
+    ]);
+
     const urgentUpdates = updates.filter((update) => update.urgent);
 
-    // Calculate days to next meeting (mock for now - should integrate with meeting system)
-    const nextMeetingDate = new Date("2025-10-05T10:00:00"); // Should be dynamic
-    const today = new Date();
-    const daysToMeeting = Math.ceil(
-      (nextMeetingDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
-    );
+    let daysToMeeting = 0;
+    if (nextSession?.startAt) {
+      const nextMeetingDate = new Date(nextSession.startAt);
+      if (!Number.isNaN(nextMeetingDate.getTime())) {
+        daysToMeeting = Math.max(
+          0,
+          Math.ceil((nextMeetingDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24))
+        );
+      }
+    }
 
     const stats: StatsData = {
       totalUpdates: updates.length,
       urgentItems: urgentUpdates.length,
-      activeMembers: 8, // Fixed for the 8-person circle
-      daysToMeeting: Math.max(0, daysToMeeting),
+      activeMembers: 8,
+      daysToMeeting,
     };
 
     logger.debug("Returning stats", { stats });

--- a/src/app/api/updates/route.ts
+++ b/src/app/api/updates/route.ts
@@ -1,0 +1,44 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { logger } from "@/lib/logger";
+import { getOptionalUserSession } from "@/lib/session";
+import { TursoUnavailableError } from "@/lib/turso";
+import { fetchUpdates } from "@/lib/updates";
+
+export async function GET(request: NextRequest) {
+  const session = await getOptionalUserSession();
+  if (!session?.user?.email) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "UNAUTHENTICATED", message: "Authentication required." },
+      },
+      { status: 401 }
+    );
+  }
+
+  const { searchParams } = request.nextUrl;
+  const limit = Math.min(Math.max(Number(searchParams.get("limit") ?? 200), 1), 500);
+  const offset = Math.max(Number(searchParams.get("offset") ?? 0), 0);
+
+  try {
+    const updates = await fetchUpdates(session.user.email, { limit, offset });
+    return NextResponse.json({ ok: true, updates });
+  } catch (error) {
+    logger.error("Failed to fetch updates", { error });
+    const unavailable = error instanceof TursoUnavailableError;
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: unavailable ? "DATABASE_UNAVAILABLE" : "FETCH_FAILED",
+          message: unavailable
+            ? "Updates cannot be loaded because the database is currently unavailable."
+            : "Unable to load updates right now. Please try again soon.",
+        },
+      },
+      { status: 503 }
+    );
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,8 +5,8 @@ import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Unstable_Grid2";
 
 import { NextSessionCard } from "@/app/(protected)/_components/next-session-card";
-import { getNextSession } from "@/lib/turso";
 import { requireUserSession } from "@/lib/session";
+import { getNextSession } from "@/lib/turso";
 
 // Revalidate every 60 seconds for semi-static rendering
 export const revalidate = 60;

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,6 +1,6 @@
-import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import type { Session } from "next-auth";
+import { getServerSession } from "next-auth";
 
 import { authOptions } from "@/../auth";
 import { logger } from "@/lib/logger";


### PR DESCRIPTION
…ock data

- Add GET /api/updates route so UpdatesBoard can safely refetch from browser
- Fix UpdatesBoard queryFn to call /api/updates instead of server-only fetchUpdates() (refetchInterval:30s was silently failing in the browser every 30 seconds)
- Fix /api/stats: return 401 for unauthenticated requests instead of mock data
- Fix /api/stats: calculate daysToMeeting from real next_session DB record (hardcoded 2025-10-05 date was already in the past)
- Fix next-session-card: replace window.location.reload() with router.refresh()
- Fix /api/meetings/upcoming: replace 2025 mock data with real getNextSession() data
- Remove dead updates-summary.tsx (contained only a deprecation comment)